### PR TITLE
Action now only starts on releasing a new tag

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -3,8 +3,8 @@ name: Release Helm charts to GCS
 
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - 'v*'
     paths:
       - "charts/**"
   workflow_dispatch:


### PR DESCRIPTION
Action now only starts on releasing a new tag