### PR TITLE
New Flink job chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,13 @@ jobs:
           name: cheetah-flink-native
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: flink-job
+        uses: ./.github/actions/release-chart
+        continue-on-error: true
+        with:
+          name: flink-job
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: image-automation
         uses: ./.github/actions/release-chart
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ This includes tools such as `helm`, `ct`, and `kubectl`.
 For example, to render out the full manifest from the `flink-job` Helm chart, run something like:
 
 ```bash
-helm template my-test charts/flink-job -f charts/flink-job/ci/example.yaml --dependency-update > output.yaml
+helm template my-test charts/flink-job -f charts/flink-job/ci/example-values.yaml --dependency-update > output.yaml
 ```
 
-This will render the templates in `charts/flink-job` using values in `charts/flink-job/ci/example.yaml` and outputting them to `output.yaml` as a release called `my-test`.
+This will render the templates in `charts/flink-job` using values in `charts/flink-job/ci/example-values.yaml` and outputting them to `output.yaml` as a release called `my-test`.
 The `--dependency-update` flag makes sure that local chart dependencies are up to date.
 It is not required after having run it once.
 
@@ -77,13 +77,13 @@ Sometimes Helm is not able to generate the template even with `--debug`.
 When this happens, it is most likely due to a nil pointer exception.
 One of these errors might look like the following:
 
-> `Error: template: flink-job/templates/podmonitor.yaml:1:14: executing "flink-job/templates/podmonitor.yaml" at <.Values.monitoringg.enabled>: nil pointer evaluating interface {}.enabled`
+> `Error: template: flink-job/templates/podmonitor.yaml:1:14: executing "flink-job/templates/podmonitor.yaml" at <.Values.metrics.podmonitor.enabled>: nil pointer evaluating interface {}.enabled`
 
 In this case it is caused by a spelling mistake in line `1` in `podmonitor.yaml`.
-I am trying to access `.Values.monitoringg.enabled` instead of `.Values.monitoring.enabled`.
-As I haven't defined the `monitoringg` object in the values file, Helm (or rather, Go) errors out when I am trying to access the `enabled` key in the object.
+I am trying to access `.Values.metrics.podmonitor.enabled` instead of `.Values.metrics.podMonitor.enabled`.
+As I haven't defined the `podmonitor` object in the values file, Helm (or rather, Go) errors out when I am trying to access the `enabled` key in the object.
 
-Changing the reference from `.Values.monitoringg.enabled` to `.Values.monitoring.enabled`, the `helm template` is successful again.
+Changing the reference from `.Values.metrics.podmonitor.enabled` to `.Values.metrics.podMonitor.enabled`, the `helm template` is successful again.
 
 To run the linting command (the same included in `Makefile`), run:
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ helm template releaseName oci://ghcr.io/trifork/cheetah-charts/<chartName> [--ve
 You can find the available versions under [packages](https://github.com/orgs/trifork/packages?repo_name=cheetah-charts).
 Helm does not currently support searching for versions in OCI repositories.
 
-<!-- TODO 
-### Install from GitHub releases 
-Requires a hosted index.yaml which points to the releases
--->
+### Install from GitHub releases
+
+Currently, this is not possible as it requires a publicly hosted `index.yaml`.
 
 ## Contributing
 
@@ -61,13 +60,13 @@ Unfortunately, this Docker container does not include `make`, so it is not possi
 However, the other tools which are included in this shell, is very useful.
 This includes tools such as `helm`, `ct`, and `kubectl`.
 
-For example, to render out the full manifest from the `cheetah-flink-native` Helm chart, run something like:
+For example, to render out the full manifest from the `flink-job` Helm chart, run something like:
 
 ```bash
-helm template my-test charts/cheetah-flink-native -f charts/cheetah-flink-native/ci/example.yaml --dependency-update > output.yaml
+helm template my-test charts/flink-job -f charts/flink-job/ci/example.yaml --dependency-update > output.yaml
 ```
 
-This will render the templates in `charts/cheetah-flink-native` using values in `charts/cheetah-flink-native/ci/example.yaml` and outputting them to `output.yaml` as a release called `my-test`.
+This will render the templates in `charts/flink-job` using values in `charts/flink-job/ci/example.yaml` and outputting them to `output.yaml` as a release called `my-test`.
 The `--dependency-update` flag makes sure that local chart dependencies are up to date.
 It is not required after having run it once.
 
@@ -78,7 +77,7 @@ Sometimes Helm is not able to generate the template even with `--debug`.
 When this happens, it is most likely due to a nil pointer exception.
 One of these errors might look like the following:
 
-> `Error: template: cheetah-flink-native/templates/podmonitor.yaml:1:14: executing "cheetah-flink-native/templates/podmonitor.yaml" at <.Values.monitoringg.enabled>: nil pointer evaluating interface {}.enabled`
+> `Error: template: flink-job/templates/podmonitor.yaml:1:14: executing "flink-job/templates/podmonitor.yaml" at <.Values.monitoringg.enabled>: nil pointer evaluating interface {}.enabled`
 
 In this case it is caused by a spelling mistake in line `1` in `podmonitor.yaml`.
 I am trying to access `.Values.monitoringg.enabled` instead of `.Values.monitoring.enabled`.

--- a/charts/flink-job/.helmignore
+++ b/charts/flink-job/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/flink-job/Chart.yaml
+++ b/charts/flink-job/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: flink-job
+description: A Helm chart for handling Cheetah Data Platform Flink jobs
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+dependencies:
+  - name: image-automation
+    condition: image-automation.enabled
+    version: "*"
+    repository: file://../image-automation
+    tags:
+      - flux
+      - automation

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -117,7 +117,7 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | restartNonce | int | `0` | change this to force a restart of the job, see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info |
 | logConfiguration | object | `{}` | Custom logging configuration |
 | mode | string | `"native"` | Cluster deployment mode. Support values are `native` and `standalone` `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes |
-| storage.scheme | string | `""` | File storage scheme. Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc. (Note the exclusion of `://`) |
+| storage.scheme | string | `""` | File storage scheme. Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc. |
 | storage.baseDir | string | `""` | Set the base directory for the HA, savepoints, and checkpoints storage. Generates a directory tree, based on the file system scheme, base directory, release name, and storage type (savepoint, checkpoint, or HA metadata) |
 | ports | list | `[]` | Extra ports to open on both job- and task-manager |
 | env | list | `[]` | Extra environment variables to set on both job- and task-manager |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -135,6 +135,7 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | job.savepointTriggerNonce | int | `0` | change this to trigger a savepoint manually, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
 | job.initialSavepointPath | string | `""` | change this to force a manual recovery checkpoint, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
 | job.allowNonRestoredState | bool | `false` | If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed. |
+| job.topics | list | `[]` | Define which topics this job will consume. Used for data-discovery in Cheetah Backstage. If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job See `values.yaml` for the format |
 | podTemplate | string | (see values.yaml) | Shared job-/task-manager pod template. Overridden by `(job/task)Manager.podTemplate`. The main flink-container must be called "flink-main-container" |
 | taskManager.replicas | int | `1` | Number of replicas |
 | taskManager.resource.memory | string | `"1Gb"` | Memory to reserve for each Task Manager. The amount needed depends on the amount of data to be processed by each Task Manager, and how much state it should store in memory. |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -23,10 +23,12 @@ A Helm chart for handling Cheetah Data Platform Flink jobs
 | image.pullPolicy | string | `"Always"` | Which image pull policy to use |
 | imagePullSecrets | list | `[]` | Image pull secrets. A list of `name: <secret-name>` |
 | version | string | `"v1_15"` | Which Flink version to use |
-| flinkConfiguration | object | `{"execution.checkpointing.interval":"10 minutes","execution.checkpointing.min-pause":"10 minutes","execution.checkpointing.timeout":"5 minutes","high-availability":"org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory","kubernetes.jobmanager.cpu.limit-factor":"10.0","kubernetes.taskmanager.cpu.limit-factor":"10.0","rest.flamegraph.enabled":"true","state.backend":"hashmap","taskmanager.numberOfTaskSlots":"2"}` | Flink configuration For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |
+| flinkConfiguration | object | `{"execution.checkpointing.interval":"10 minutes","execution.checkpointing.min-pause":"10 minutes","execution.checkpointing.timeout":"5 minutes","kubernetes.jobmanager.cpu.limit-factor":"10.0","kubernetes.taskmanager.cpu.limit-factor":"10.0","rest.flamegraph.enabled":"true","state.backend":"hashmap","taskmanager.numberOfTaskSlots":"2"}` | Flink configuration For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |
 | restartNonce | int | `0` | change this to force a restart of the job, see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info |
 | logConfiguration | object | `{}` | Custom logging configuration |
 | mode | string | `"native"` | Cluster deployment mode. Support values are `native` and `standalone` `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes |
+| storage.scheme | string | `""` | File storage scheme. Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc. (Note the exclusion of `://`) |
+| storage.baseDir | string | `""` | Set the base directory for the HA, savepoints, and checkpoints storage. Generates a directory tree, based on the file system scheme, base directory, release name, and storage type |
 | ports | list | `[]` | Extra ports to open on both job- and task-manager |
 | env | list | `[]` | Extra environment variables to set on both job- and task-manager |
 | envFrom | list | `[]` | List of ConfigMap/Secrets where environment variables can be loaded from |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -129,13 +129,13 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | job.jarURI | string | `""` | The path of the job jar |
 | job.entryClass | string | `""` | The name of the job class |
 | job.args | list | `[]` | Arguments for the job |
+| job.topics | list | `[]` | Define which topics this job will consume. Used for data-discovery in Cheetah Backstage. If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job See `values.yaml` for the format |
 | job.parallelism | int | `2` | How many jobs to run in parallel, see more here: <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/execution/parallel/> |
 | job.state | string | `"running"` | Desired state of the job. Must be either: `running` or `suspended` |
 | job.upgradeMode | string | `"savepoint"` | Application upgrade mode. Must be either: stateless, last_state, savepoint `stateless` upgrades is done from an empty state `last-state` does a quick upgrade. Does not require the job to be in a healthy state `savepoint` makes use of savepoints when upgrading and requires the job to be running. This provides maximal safety Read more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/#stateful-and-stateless-application-upgrades> |
 | job.savepointTriggerNonce | int | `0` | change this to trigger a savepoint manually, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
 | job.initialSavepointPath | string | `""` | change this to force a manual recovery checkpoint, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
 | job.allowNonRestoredState | bool | `false` | If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed. |
-| job.topics | list | `[]` | Define which topics this job will consume. Used for data-discovery in Cheetah Backstage. If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job See `values.yaml` for the format |
 | podTemplate | string | (see values.yaml) | Shared job-/task-manager pod template. Overridden by `(job/task)Manager.podTemplate`. The main flink-container must be called "flink-main-container" |
 | taskManager.replicas | int | `1` | Number of replicas |
 | taskManager.resource.memory | string | `"1Gb"` | Memory to reserve for each Task Manager. The amount needed depends on the amount of data to be processed by each Task Manager, and how much state it should store in memory. |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -1,0 +1,107 @@
+# flink-job
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for handling Cheetah Data Platform Flink jobs
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../image-automation | image-automation | * |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| global | object | `{"image":{"repository":""},"imagePullSecrets":[]}` | Only used to decrease duplicate configuration of this chart, if image-automation is used as a sub chart. Overrides the local values if given |
+| image.repository | string | `"flink"` | Which image repository to use |
+| image.tag | string | `"main"` | Which image tag to use |
+| image.sha | string | `""` | Which image sha to use. If used, the `image.tag` is ignored |
+| image.pullPolicy | string | `"Always"` | Which image pull policy to use |
+| imagePullSecrets | list | `[]` | Image pull secrets. A list of `name: <secret-name>` |
+| version | string | `"v1_15"` | Which Flink version to use |
+| flinkConfiguration | object | `{"execution.checkpointing.interval":"10 minutes","execution.checkpointing.min-pause":"10 minutes","execution.checkpointing.timeout":"5 minutes","high-availability":"org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory","kubernetes.jobmanager.cpu.limit-factor":"10.0","kubernetes.taskmanager.cpu.limit-factor":"10.0","rest.flamegraph.enabled":"true","state.backend":"hashmap","taskmanager.numberOfTaskSlots":"2"}` | Flink configuration For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |
+| restartNonce | int | `0` | change this to force a restart of the job, see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info |
+| logConfiguration | object | `{}` | Custom logging configuration |
+| mode | string | `"native"` | Cluster deployment mode. Support values are `native` and `standalone` `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes |
+| ports | list | `[]` | Extra ports to open on both job- and task-manager |
+| env | list | `[]` | Extra environment variables to set on both job- and task-manager |
+| envFrom | list | `[]` | List of ConfigMap/Secrets where environment variables can be loaded from |
+| volumes | list | `[]` | List of additional volumes for the both job- and task-manager |
+| volumeMounts | list | `[]` | List of additional volume mounts for the both job- and task-manager |
+| podLabels | object | `{}` | Additional labels attached to the pods |
+| podAnnotations | object | `{}` | Additional annotations attached to the pods |
+| job.jarURI | string | `""` | The path of the job jar |
+| job.entryClass | string | `""` | The name of the job class |
+| job.args | list | `[]` | Arguments for the job |
+| job.parallelism | int | `2` | How many jobs to run in parallel, see more here: <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/execution/parallel/> |
+| job.state | string | `"running"` | Desired state of the job. Must be either: `running` or `suspended` |
+| job.upgradeMode | string | `"savepoint"` | Application upgrade mode. Must be either: stateless, last_state, savepoint `stateless` upgrades is done from an empty state `last-state` does a quick upgrade. Does not require the job to be in a healthy state `savepoint` makes use of savepoints when upgrading and requires the job to be running. This provides maximal safety Read more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/#stateful-and-stateless-application-upgrades> |
+| job.savepointTriggerNonce | int | `0` | change this to trigger a savepoint manually, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
+| job.initialSavepointPath | string | `""` | change this to force a manual recovery checkpoint, see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> |
+| job.allowNonRestoredState | bool | `false` | If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed. |
+| podTemplate | string | (see values.yaml) | Shared job-/task-manager pod template. Overridden by `(job/task)Manager.podTemplate`. The main flink-container must be called "flink-main-container" |
+| taskManager.replicas | int | `1` | Number of replicas |
+| taskManager.resource.memory | string | `"1Gb"` | Memory to reserve for each Task Manager. The amount needed depends on the amount of data to be processed by each Task Manager, and how much state it should store in memory. |
+| taskManager.resource.cpu | float | `0.1` | CPU requests. CPU limits is CPU requests multiplied by flinkConfiguration."kubernetes.jobmanager.cpu.limit-factor" |
+| taskManager.ports | list | `[]` | Extra ports to open |
+| taskManager.env | list | `[]` | Extra environment variables |
+| taskManager.envFrom | list | `[]` | List of ConfigMap/Secrets where environment variables can be loaded from |
+| taskManager.volumes | list | `[]` | List of additional volumes |
+| taskManager.volumeMounts | list | `[]` | List of additional volume mounts |
+| taskManager.podLabels | object | `{}` | Additional labels attached to the pods |
+| taskManager.podAnnotations | object | `{}` | Additional annotations attached to the pods |
+| taskManager.podTemplate | string | (see values.yaml) | Pod template. Overrides the main `podTemplate`. The main flink-container must be called "flink-main-container" |
+| jobManager.replicas | int | `1` | Number of replicas |
+| jobManager.resource.memory | string | `"1Gb"` | Memory to reserve for the Job Manager. The default value should be ok for most jobs. |
+| jobManager.resource.cpu | float | `0.1` | CPU requests. CPU limits is CPU requests multiplied by flinkConfiguration."kubernetes.jobmanager.cpu.limit-factor" |
+| jobManager.ports | list | `[]` | Extra ports to open |
+| jobManager.env | list | `[]` | Extra environment variables |
+| jobManager.envFrom | list | `[]` | List of ConfigMap/Secrets where environment variables can be loaded from |
+| jobManager.volumes | list | `[]` | List of additional volumes |
+| jobManager.volumeMounts | list | `[]` | List of additional volume mounts |
+| jobManager.podLabels | object | `{}` | Additional labels attached to the pods |
+| jobManager.podAnnotations | object | `{}` | Additional annotations attached to the pods |
+| jobManager.podTemplate | string | (see values.yaml) | Pod template. Overrides the main `podTemplate`. The main flink-container must be called "flink-main-container" |
+| metrics.enabled | bool | `true` | Enable metrics scraping. Define flinkProperties to define the monitoring properties |
+| metrics.port | int | `9249` | Port on both job- and task-manager where metrics are exposed |
+| metrics.podMonitor.enabled | bool | `true` |  |
+| metrics.podMonitor.path | string | `""` | Override the metrics scrape path |
+| metrics.podMonitor.interval | string | `""` | Override the default scrape interval |
+| metrics.podMonitor.scrapeTimeout | string | `""` | Override the default scrape timeout |
+| metrics.podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
+| metrics.podMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
+| metrics.podMonitor.selectors | object | `{}` | Extra pod selector labels |
+| metrics.podMonitor.labels | object | `{}` | Extra PodMonitor labels |
+| metrics.podMonitor.extraMetricsEndpoints | list | `[]` | Extra podmonitor metrics endpoints |
+| metrics.podMonitor.targetLabels | list | `["component","cluster"]` | Copy pod labels onto the metrics targets |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account tokens |
+| rbac.create | bool | `true` | Specifies whether a Role and RoleBinding should be created |
+| rbac.additionalRules | list | `[]` | Additional rules to add to the role |
+| podSecurityContext.runAsNonRoot | bool | `true` | Whether to run the pod without root capabilities |
+| podSecurityContext.fsGroup | int | `9999` | Add a supplimentary group ID to all processes in the container. Set the owner of all volumes to this group |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Which secure computing mode (seccomp) profile to use |
+| securityContext.allowPrivilegeEscalation | bool | `false` | Allow privilege escalation |
+| securityContext.runAsGroup | int | `9999` | User to run the container as |
+| securityContext.runAsUser | int | `9999` | Group to add the user to |
+| securityContext.capabilities.drop | list | `["ALL"]` | Linux capabilities to drop |
+| securityContext.capabilities.add | list | `[]` | Linux capabilities to add |
+| ingress.enabled | bool | `false` | Whether to expose the Flink UI, on the job-manager |
+| ingress.uiPort | int | `8081` | Flink UI port. Ingress will hit the service on this port |
+| ingress.ingressClassName | string | `""` | Ingress controller name |
+| ingress.hostname | string | `"flink.cheetah.trifork.dev"` | Which host name to use for the Flink UI |
+| ingress.path | string | `"/"` | Which subpath to expose the Flink UI under |
+| ingress.pathType | string | `"ImplementationSpecific"` | Which path type to use |
+| ingress.annotations | object | `{}` | Extra Ingress annotations |
+| ingress.tlsSecret | string | `""` | Add TLS certificates from an existing secret |
+| ingress.selfSigned | bool | `false` | Create a self-signed TLS secret |
+| image-automation | object | `{"enabled":false}` | Settings passed to the image-automation chart, Image-automation is not possible when using image-sha as a tagging strategy |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -4,6 +4,12 @@
 
 A Helm chart for handling Cheetah Data Platform Flink jobs
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../image-automation | image-automation | * |
+
 ## Usage
 
 ### Keeping state
@@ -93,12 +99,6 @@ However, for guarenteed availability, it is possible to run the job-manager in m
 Whenever `jobManager.replicas > 1` is set, a helper function will set the needed configuration in `flinkConfiguration`.
 
 Read more about Flink and highly available job-managers [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/).
-
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| file://../image-automation | image-automation | * |
 
 ## Values
 

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -4,6 +4,96 @@
 
 A Helm chart for handling Cheetah Data Platform Flink jobs
 
+## Usage
+
+### Keeping state
+
+For setting up savepoint/checkpoint/HA metadata state, it is possible to make use of a helper function.
+This is done by setting `storage.scheme` and `storage.baseDir`.
+These configure the file system scheme (such as local file system, Amazon S3, Azure Blob Storage), and the base directory in the file system (such as `/flink/data`), respectively.
+See [below](#values) for documentation on how to use these.
+
+It is possible to use local storage such as a Persistent Volume or using a path directly on the host node (not recommended).
+This can be a nice to use for development and quick testing, but is not recommended for production as many Kubernetes distributions doesn't support `ReadWriteMany` access modes.
+To set up using a Persistent Volume for storage, create a Persistent Volume Claim similar to this:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flink-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard
+```
+
+Mounting the Persistent Volume created by the `standard` StorageClass, is done by setting the following in the values file:
+
+```yaml
+volumeMounts:
+  - mountPath: /flink-data
+    name: flink-volume
+volumes:
+  - name: flink-volume
+    persistentVolumeClaim:
+      claimName: flink-volume
+```
+
+To tell the Flink job to use the `/flink-data` directory for file storage, set:
+
+```yaml
+storage:
+  scheme: file
+  baseDir: /flink-data
+```
+
+This tells Flink where to keep savepoint, checkpoint, and HA metadata data (if applicable).
+
+Depending on which file system to use for keeping state, custom configuration might be required.
+For example, to set up storage to an S3 bucket at the `/flink/data` directory, set `storage.scheme=s3` and `storage.baseDir=/flink/data`.
+Authentication is done using the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables (the `AWS_` prefix is required for all S3-like storage systems, even if AWS has nothing to do with it).
+If these are kept in a secret looking like this
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-credentials
+data:
+  AWS_ACCESS_KEY: YWNjZXNzLWtleQ==
+  AWS_SECRET_KEY: c2VjcmV0LWtleQ==
+```
+
+the environment variables can be loaded by setting
+
+```yaml
+envFrom:
+  - secretRef:
+      name: s3-credentials
+```
+
+This adds the environment variables from the `s3-credentials` Secret to both the job- and task-manager(s).
+It is also necessary to set the `flinkConfiguration."s3.endpoint"` to the endpoint of your S3 system.
+
+Sometimes it is also necessary to set `flinkConfiguration."s3.path-style-access"="true"`, in order to work around some S3 object stores not having virtual host style addressing enabled (such as with MinIO).
+See <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/s3/> for more documentation on S3 and Flink.
+
+### Job-manager HA mode
+
+By default, there is a single JobManager instance per Flink cluster.
+This creates a single point of failure (SPOF): if the JobManager crashes, no new programs can be submitted and running programs fail.
+
+This is normally not a problem with the Flink operator, as the job-manager is owned by a single-replica Kubernetes Deployment/ReplicaSet, which will start a new job-manager pod up if it crashes.
+However, for guarenteed availability, it is possible to run the job-manager in multi-replica mode, using a leader election system.
+
+Whenever `jobManager.replicas > 1` is set, a helper function will set the needed configuration in `flinkConfiguration`.
+
+Read more about Flink and highly available job-managers [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/).
+
 ## Requirements
 
 | Repository | Name | Version |
@@ -28,7 +118,7 @@ A Helm chart for handling Cheetah Data Platform Flink jobs
 | logConfiguration | object | `{}` | Custom logging configuration |
 | mode | string | `"native"` | Cluster deployment mode. Support values are `native` and `standalone` `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes |
 | storage.scheme | string | `""` | File storage scheme. Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc. (Note the exclusion of `://`) |
-| storage.baseDir | string | `""` | Set the base directory for the HA, savepoints, and checkpoints storage. Generates a directory tree, based on the file system scheme, base directory, release name, and storage type |
+| storage.baseDir | string | `""` | Set the base directory for the HA, savepoints, and checkpoints storage. Generates a directory tree, based on the file system scheme, base directory, release name, and storage type (savepoint, checkpoint, or HA metadata) |
 | ports | list | `[]` | Extra ports to open on both job- and task-manager |
 | env | list | `[]` | Extra environment variables to set on both job- and task-manager |
 | envFrom | list | `[]` | List of ConfigMap/Secrets where environment variables can be loaded from |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -112,7 +112,7 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | image.sha | string | `""` | Which image sha to use. If used, the `image.tag` is ignored |
 | image.pullPolicy | string | `"Always"` | Which image pull policy to use |
 | imagePullSecrets | list | `[]` | Image pull secrets. A list of `name: <secret-name>` |
-| version | string | `"v1_15"` | Which Flink version to use |
+| version | string | `"v1_16"` | Which Flink version to use |
 | flinkConfiguration | object | `{"execution.checkpointing.interval":"10 minutes","execution.checkpointing.min-pause":"10 minutes","execution.checkpointing.timeout":"5 minutes","kubernetes.jobmanager.cpu.limit-factor":"10.0","kubernetes.taskmanager.cpu.limit-factor":"10.0","rest.flamegraph.enabled":"true","state.backend":"hashmap","taskmanager.numberOfTaskSlots":"2"}` | Flink configuration For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |
 | restartNonce | int | `0` | change this to force a restart of the job, see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info |
 | logConfiguration | object | `{}` | Custom logging configuration |

--- a/charts/flink-job/README.md.gotmpl
+++ b/charts/flink-job/README.md.gotmpl
@@ -5,6 +5,14 @@
 
 {{ template "chart.description" . }}
 
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
 ## Usage
 
 ### Keeping state
@@ -94,14 +102,6 @@ However, for guarenteed availability, it is possible to run the job-manager in m
 Whenever `jobManager.replicas > 1` is set, a helper function will set the needed configuration in `flinkConfiguration`.
 
 Read more about Flink and highly available job-managers [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/).
-
-{{ template "chart.homepageLine" . }}
-
-{{ template "chart.maintainersSection" . }}
-
-{{ template "chart.sourcesSection" . }}
-
-{{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/flink-job/README.md.gotmpl
+++ b/charts/flink-job/README.md.gotmpl
@@ -1,0 +1,108 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+## Usage
+
+### Keeping state
+
+For setting up savepoint/checkpoint/HA metadata state, it is possible to make use of a helper function.
+This is done by setting `storage.scheme` and `storage.baseDir`.
+These configure the file system scheme (such as local file system, Amazon S3, Azure Blob Storage), and the base directory in the file system (such as `/flink/data`), respectively.
+See [below](#values) for documentation on how to use these.
+
+It is possible to use local storage such as a Persistent Volume or using a path directly on the host node (not recommended).
+This can be a nice to use for development and quick testing, but is not recommended for production as many Kubernetes distributions doesn't support `ReadWriteMany` access modes.
+To set up using a Persistent Volume for storage, create a Persistent Volume Claim similar to this:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flink-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard
+```
+
+Mounting the Persistent Volume created by the `standard` StorageClass, is done by setting the following in the values file:
+
+```yaml
+volumeMounts:
+  - mountPath: /flink-data
+    name: flink-volume
+volumes:
+  - name: flink-volume
+    persistentVolumeClaim:
+      claimName: flink-volume
+```
+
+To tell the Flink job to use the `/flink-data` directory for file storage, set:
+
+```yaml
+storage:
+  scheme: file
+  baseDir: /flink-data
+```
+
+This tells Flink where to keep savepoint, checkpoint, and HA metadata data (if applicable).
+
+Depending on which file system to use for keeping state, custom configuration might be required.
+For example, to set up storage to an S3 bucket at the `/flink/data` directory, set `storage.scheme=s3` and `storage.baseDir=/flink/data`.
+Authentication is done using the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables (the `AWS_` prefix is required for all S3-like storage systems, even if AWS has nothing to do with it).
+If these are kept in a secret looking like this
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-credentials
+data:
+  AWS_ACCESS_KEY: YWNjZXNzLWtleQ==
+  AWS_SECRET_KEY: c2VjcmV0LWtleQ==
+```
+
+the environment variables can be loaded by setting
+
+```yaml
+envFrom:
+  - secretRef:
+      name: s3-credentials
+```
+
+This adds the environment variables from the `s3-credentials` Secret to both the job- and task-manager(s).
+It is also necessary to set the `flinkConfiguration."s3.endpoint"` to the endpoint of your S3 system.
+
+Sometimes it is also necessary to set `flinkConfiguration."s3.path-style-access"="true"`, in order to work around some S3 object stores not having virtual host style addressing enabled (such as with MinIO).
+See <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/s3/> for more documentation on S3 and Flink.
+
+### Job-manager HA mode
+
+By default, there is a single JobManager instance per Flink cluster.
+This creates a single point of failure (SPOF): if the JobManager crashes, no new programs can be submitted and running programs fail.
+
+This is normally not a problem with the Flink operator, as the job-manager is owned by a single-replica Kubernetes Deployment/ReplicaSet, which will start a new job-manager pod up if it crashes.
+However, for guarenteed availability, it is possible to run the job-manager in multi-replica mode, using a leader election system.
+
+Whenever `jobManager.replicas > 1` is set, a helper function will set the needed configuration in `flinkConfiguration`.
+
+Read more about Flink and highly available job-managers [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/).
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/flink-job/ci/example-values.yaml
+++ b/charts/flink-job/ci/example-values.yaml
@@ -1,0 +1,25 @@
+# example values from docs.cheetah.trifork.dev/
+image:
+  repository: flink
+  tag: 1.16
+ingress:
+  enabled: true
+  hostname: flink.cheetah.trifork.dev
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+
+version: v1_16
+job:
+  jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+  entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
+  parallelism: 2
+taskManager:
+  replicas: 2
+  resource:
+    memory: 2Gb
+    cpu: 0.5
+jobManager:
+  replicas: 2
+
+metrics:
+  enabled: true

--- a/charts/flink-job/ci/example-values.yaml
+++ b/charts/flink-job/ci/example-values.yaml
@@ -6,7 +6,8 @@ ingress:
   enabled: true
   hostname: flink.cheetah.trifork.dev
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt"
+    cert-manager.io/cluster-issuer: letsencrypt
+  tlsSecret: letsencrypt
 
 version: v1_16
 job:

--- a/charts/flink-job/ci/example-values.yaml
+++ b/charts/flink-job/ci/example-values.yaml
@@ -9,6 +9,10 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt
   tlsSecret: letsencrypt
 
+storage:
+  scheme: s3
+  baseDir: /flink-data
+
 version: v1_16
 job:
   jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -55,7 +55,9 @@ podAnnotations:
 job:
   jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
   entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
-  args: []
+  args:
+    - --kafka-bootstrap-servers
+    - kafka:9092
   topics:
     - type: input
       name: defaultTopic
@@ -73,56 +75,25 @@ job:
   initialSavepointPath: ""
   allowNonRestoredState: false
 
-podTemplate: |-
-  metadata:
-    labels:
-      app.kubernetes.io/component: metrics
-      {{- include "flink-job.backstageLabels" . | nindent 4 }}
-      {{- include "flink-job.selectorLabels" . | nindent 4 }}
-      {{- toYaml .Values.metrics.podMonitor.selectors | nindent 4 }}
-      {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
-    {{- with .Values.podAnnotations }}
-    annotations:
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-  spec:
-    securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 4 }}
-    containers:
-      - name: flink-main-container
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 8 }}
-        {{- with .Values.env }}
-        env:
-          {{- toYaml . | nindent 8 -}}
-        {{- end }}
-        {{- with .Values.envFrom }}
-        envFrom:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        ports:
-          {{- with .Values.ports }}
-          {{- toYaml . | nindent 8 -}}
-          {{- end }}
-          {{- if .Values.metrics.enabled }}
-          - name: metrics
-            containerPort: {{ .Values.metrics.port }}
-          {{- end }}
-        {{- with .Values.volumeMounts }}
-        volumeMounts:
-          {{- toYaml . | nindent 8 -}}
-        {{- end }}
-    {{- with .Values.volumes }}
-    volumes:
-      {{- toYaml . | nindent 4 -}}
-    {{- end }}
-    {{ $imagepullsecrets := coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets }}
-    {{- with $imagepullsecrets -}}
-    imagePullSecrets:
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+# podTemplate: |-
+#   metadata:
+#     labels:
+#       {{- include "flink-job.podLabels" . | nindent 4 }}
+#     {{- with .Values.podAnnotations }}
+#     annotations:
+#       {{- toYaml . | nindent 4 }}
+#     {{- end }}
+#   spec:
+#     securityContext:
+#       {{- toYaml .Values.podSecurityContext | nindent 4 }}
+#     containers:
+#       - name: flink-main-container
+#         securityContext:
+#           {{- toYaml .Values.securityContext | nindent 8 }}
+#     {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+#     imagePullSecrets:
+#       {{- toYaml . | nindent 4 }}
+#     {{- end }}
 
 taskManager:
   replicas: 2
@@ -152,10 +123,11 @@ taskManager:
 
   podTemplate: |-
     metadata:
-      {{- with .Values.taskManager.podLabels }}
       labels:
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
+        foo: bar
+        {{- with .Values.taskManager.podLabels }}
+          {{- toYaml . | nindent 4 }}
+        {{- end }}
       {{- with .Values.taskManager.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 4 }}
@@ -163,23 +135,27 @@ taskManager:
     spec:
       containers:
         - name: flink-main-container
-          {{- with .Values.taskManager.ports }}
           ports:
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+          {{- with (concat .Values.ports .Values.taskManager.ports) }}
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.taskManager.env }}
+          {{- with (concat .Values.env .Values.taskManager.env) }}
           env:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.taskManager.envFrom }}
+          {{- with (concat .Values.envFrom .Values.taskManager.envFrom) }}
           envFrom:
-            {{- toYaml . | nindent 8 -}}
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-          {{- with .Values.taskManager.volumeMounts }}
+          {{- with (concat .Values.volumeMounts .Values.taskManager.volumeMounts) }}
           volumeMounts:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-      {{- with .Values.taskManager.volumes }}
+      {{- with (concat .Values.volumes .Values.taskManager.volumes) }}
       volumes:
         {{- toYaml . | nindent 4 -}}
       {{- end }}
@@ -224,24 +200,26 @@ jobManager:
       containers:
         - name: flink-main-container
           ports:
-            - name: ui
-              containerPort: {{ .Values.ingress.uiPort }}
-              {{- with .Values.jobManager.ports }}
-              {{- toYaml . | nindent 8 -}}
-              {{- end }}
-          {{- with .Values.jobManager.env }}
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+          {{- with (concat .Values.ports .Values.jobManager.ports) }}
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with (concat .Values.env .Values.jobManager.env) }}
           env:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.jobManager.envFrom }}
+          {{- with (concat .Values.envFrom .Values.jobManager.envFrom) }}
           envFrom:
-            {{- toYaml . | nindent 8 -}}
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-          {{- with .Values.jobManager.volumeMounts }}
+          {{- with (concat .Values.volumeMounts .Values.jobManager.volumeMounts) }}
           volumeMounts:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-      {{- with .Values.jobManager.volumes }}
+      {{- with (concat .Values.volumes .Values.jobManager.volumes) }}
       volumes:
         {{- toYaml . | nindent 4 -}}
       {{- end }}

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -28,7 +28,7 @@ logConfiguration:
     turn: off
 
 storage:
-  scheme: s3
+  scheme: s3://
   baseDir: /flink-data
 
 ports:
@@ -75,25 +75,25 @@ job:
   initialSavepointPath: ""
   allowNonRestoredState: false
 
-# podTemplate: |-
-#   metadata:
-#     labels:
-#       {{- include "flink-job.podLabels" . | nindent 4 }}
-#     {{- with .Values.podAnnotations }}
-#     annotations:
-#       {{- toYaml . | nindent 4 }}
-#     {{- end }}
-#   spec:
-#     securityContext:
-#       {{- toYaml .Values.podSecurityContext | nindent 4 }}
-#     containers:
-#       - name: flink-main-container
-#         securityContext:
-#           {{- toYaml .Values.securityContext | nindent 8 }}
-#     {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
-#     imagePullSecrets:
-#       {{- toYaml . | nindent 4 }}
-#     {{- end }}
+podTemplate: |-
+  metadata:
+    labels:
+      {{- include "flink-job.podLabels" . | nindent 4 }}
+    {{- with .Values.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  spec:
+    securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 4 }}
+    containers:
+      - name: flink-main-container
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
+    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
+    imagePullSecrets:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 
 taskManager:
   replicas: 2

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -1,0 +1,320 @@
+nameOverride: ""
+fullnameOverride: flink-override
+
+global:
+  image:
+    repository: ""
+  imagePullSecrets: []
+
+image:
+  repository: flink
+  tag: ""
+  sha: f86e49fe98ed41ecae004470a0e35c83849cc8e2c0ad558e3ff702650ccdae46 # 1.16
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ghcr
+
+version: v1_16
+
+flinkConfiguration:
+  metrics.reporters: prom
+  metrics.reporter.prom.port: "9249"
+
+restartNonce: test
+mode: standalone
+logConfiguration:
+  "log4j.conf": |-
+    turn: off
+
+ports:
+  - name: foo
+    containerPort: 9999
+env:
+  - name: FOO
+    value: BAR
+envFrom:
+  - configMapRef:
+      name: some-config
+volumes:
+  - name: data
+    emptyDir: {}
+volumeMounts:
+  - name: data
+    mountPath: /flink
+podLabels:
+  cheetah-test: "true"
+podAnnotations:
+  vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+  vault.security.banzaicloud.io/vault-role: super-user
+
+job:
+  jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+  entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
+  args: []
+
+  parallelism: 2
+  state: running
+  upgradeMode: "stateless"
+  savepointTriggerNonce: trigger!
+  initialSavepointPath: ""
+  allowNonRestoredState: false
+
+podTemplate: |-
+  metadata:
+    labels:
+      app.kubernetes.io/component: metrics
+      {{- include "flink-job.backstageLabels" . | nindent 4 }}
+      {{- include "flink-job.selectorLabels" . | nindent 4 }}
+      {{- toYaml .Values.metrics.podMonitor.selectors | nindent 4 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- with .Values.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  spec:
+    securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 4 }}
+    containers:
+      - name: flink-main-container
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- with .Values.env }}
+        env:
+          {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        ports:
+          {{- with .Values.ports }}
+          {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+          - name: metrics
+            containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 -}}
+        {{- end }}
+    {{- with .Values.volumes }}
+    volumes:
+      {{- toYaml . | nindent 4 -}}
+    {{- end }}
+    {{ $imagepullsecrets := coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets }}
+    {{- with $imagepullsecrets -}}
+    imagePullSecrets:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+
+taskManager:
+  replicas: 2
+  resource:
+    memory: 2Gb
+    cpu: 0.5
+
+  ports:
+    - name: custom-port
+      containerPort: 9998
+  env:
+    - name: FOO
+      value: BAZ
+  envFrom:
+    - secretRef:
+        name: s3-secrets
+  volumes:
+    - name: state
+      emptyDir: {}
+  volumeMounts:
+    - name: state
+      mountPath: /state
+  podLabels:
+    task-manager: "true"
+  podAnnotations:
+    task-manager: "true"
+
+  podTemplate: |-
+    metadata:
+      {{- with .Values.taskManager.podLabels }}
+      labels:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.taskManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: flink-main-container
+          {{- with .Values.taskManager.ports }}
+          ports:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.env }}
+          env:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+      {{- with .Values.taskManager.volumes }}
+      volumes:
+        {{- toYaml . | nindent 4 -}}
+      {{- end }}
+
+jobManager:
+  replicas: 1
+  resource:
+    memory: 1Gb
+    cpu: 0.1
+
+  ports:
+    - name: custom-port2
+      containerPort: 9997
+  env:
+    - name: FOO
+      value: DANCE
+  envFrom:
+    - secretRef:
+        name: s3-secrets
+  volumes:
+    - name: state
+      emptyDir: {}
+  volumeMounts:
+    - name: state
+      mountPath: /state
+  podLabels:
+    job-manager: "true"
+  podAnnotations:
+    job-manager: "true"
+
+  podTemplate: |-
+    metadata:
+      {{- with .Values.jobManager.podLabels }}
+      labels:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.jobManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: flink-main-container
+          ports:
+            - name: ui
+              containerPort: {{ .Values.ingress.uiPort }}
+              {{- with .Values.jobManager.ports }}
+              {{- toYaml . | nindent 8 -}}
+              {{- end }}
+          {{- with .Values.jobManager.env }}
+          env:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.jobManager.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.jobManager.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+      {{- with .Values.jobManager.volumes }}
+      volumes:
+        {{- toYaml . | nindent 4 -}}
+      {{- end }}
+
+metrics:
+  enabled: true
+
+  port: 9249
+
+  podMonitor:
+    enabled: true
+    path: /metrics
+    interval: 30m
+    scrapeTimeout: 5s
+    metricRelabelings:
+      - separator: ;
+        regex: (.*)
+        targetLabel: LABLE_NAME
+        replacement: VALUE
+        action: replace
+    relabelings:
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_node_name
+        targetLabel: instance
+    selectors:
+      k8s-app: mycollector
+    labels:
+      prometheus-operator: collect
+    extraMetricsEndpoints:
+      - port: exporter
+        interval: 10s
+        relabelings:
+          - action: replace
+            sourceLabels:
+              - __meta_kubernetes_pod_node_name
+            targetLabel: instance
+    targetLabels:
+      - component
+      - cluster
+      - foo
+
+serviceAccount:
+  create: true
+  annotations:
+    secure: account
+  name: test
+  automountServiceAccountToken: true
+
+rbac:
+  create: true
+  additionalRules:
+    - apiGroups:
+        - ""
+      resources:
+        - secrets
+      verbs:
+        - get
+        - list
+
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 9999
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsGroup: 9999
+  runAsUser: 9999
+  capabilities:
+    drop:
+      - ALL
+    add: []
+
+ingress:
+  enabled: true
+  uiPort: 8080
+  ingressClassName: nginx
+  hostname: flink.localhost
+  path: /
+  pathType: ImplementationSpecific
+  annotations:
+    foo: bar
+  tlsSecret: foo-secret # FIXME: is not used for the selfsigned secret
+  selfSigned: true
+
+image-automation:
+  enabled: false

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -313,7 +313,7 @@ ingress:
   pathType: ImplementationSpecific
   annotations:
     foo: bar
-  tlsSecret: foo-secret # FIXME: is not used for the selfsigned secret
+  tlsSecret: foo-secret
   selfSigned: true
 
 image-automation:

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -56,6 +56,15 @@ job:
   jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
   entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
   args: []
+  topics:
+    - type: input
+      name: defaultTopic
+    - arg: input-kafka-topic
+      type: input
+      name: sourceTopic
+    - arg: output-kafka-topic
+      type: output
+      name: sinkTopic
 
   parallelism: 2
   state: running

--- a/charts/flink-job/ci/full-values.yaml
+++ b/charts/flink-job/ci/full-values.yaml
@@ -27,6 +27,10 @@ logConfiguration:
   "log4j.conf": |-
     turn: off
 
+storage:
+  scheme: s3
+  baseDir: /flink-data
+
 ports:
   - name: foo
     containerPort: 9999
@@ -55,7 +59,7 @@ job:
 
   parallelism: 2
   state: running
-  upgradeMode: "stateless"
+  upgradeMode: "last-state"
   savepointTriggerNonce: trigger!
   initialSavepointPath: ""
   allowNonRestoredState: false

--- a/charts/flink-job/ci/local-values.yaml
+++ b/charts/flink-job/ci/local-values.yaml
@@ -1,0 +1,45 @@
+image:
+  repository: flink
+  tag: 1.16
+
+version: v1_16
+
+volumeMounts:
+  - mountPath: /flink-data
+    name: flink-volume
+volumes:
+  - name: flink-volume
+    persistentVolumeClaim:
+      claimName: flink-volume
+  - name: flink-volume
+    hostPath:
+      path: /tmp/flink
+      type: Directory
+
+storage:
+  scheme: file
+  baseDir: /flink-data
+
+job:
+  jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+  parallelism: 2
+  upgradeMode: last-state
+
+jobManager:
+  replicas: 2
+
+taskManager:
+  replicas: 2
+
+metrics:
+  enabled: true
+  podMonitor:
+    enabled: false
+
+ingress:
+  enabled: true
+  hostname: flink.localhost
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  tlsSecret: letsencrypt
+  selfSigned: true

--- a/charts/flink-job/ci/local-values.yaml
+++ b/charts/flink-job/ci/local-values.yaml
@@ -11,10 +11,6 @@ volumes:
   - name: flink-volume
     persistentVolumeClaim:
       claimName: flink-volume
-  - name: flink-volume
-    hostPath:
-      path: /tmp/flink
-      type: Directory
 
 storage:
   scheme: file

--- a/charts/flink-job/ci/local-values.yaml
+++ b/charts/flink-job/ci/local-values.yaml
@@ -20,6 +20,13 @@ job:
   jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
   parallelism: 2
   upgradeMode: last-state
+  topics:
+    - arg: input-kafka-topic
+      type: input
+      name: sourceTopic
+    - arg: output-kafka-topic
+      type: output
+      name: sinkTopic
 
 jobManager:
   replicas: 2

--- a/charts/flink-job/ci/minimal-values.yaml
+++ b/charts/flink-job/ci/minimal-values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: flink
+  tag: 1.16
+
+job:
+  jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/charts/flink-job/ci/minimal-values.yaml
+++ b/charts/flink-job/ci/minimal-values.yaml
@@ -4,3 +4,7 @@ image:
 
 job:
   jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+
+storage:
+  scheme: s3
+  baseDir: /flink-data

--- a/charts/flink-job/templates/_helpers.tpl
+++ b/charts/flink-job/templates/_helpers.tpl
@@ -84,6 +84,27 @@ Backstage labels
 */}}
 {{- define "flink-job.backstageLabels" -}}
 backstage.io/kubernetes-id: {{ .Release.Name }}
+{{ include "flink-job.topicLabels" . }}
+{{- end -}}
+
+{{- define "flink-job.topicLabels" -}}
+{{- $inputs := "" -}}
+{{- $outputs := "" -}}
+{{- range .Values.job.topics -}}
+  {{- if eq .type "input" -}}
+    {{- $inputs = printf "%s,%s" $inputs .name -}}
+  {{- else if eq .type "output" -}}
+    {{- $outputs = printf "%s,%s" $outputs .name -}}
+  {{- else -}}
+    {{- fail (printf "Topic type %s not understood. Allowed values are: input, output" .type) -}}
+  {{- end -}}
+{{- end -}}
+{{- with $inputs -}}
+backstage.io/input-kafka-topics: {{ . | trimPrefix "," }}
+{{- end }}
+{{- with $outputs }}
+backstage.io/output-kafka-topics: {{ . | trimPrefix "," }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/flink-job/templates/_helpers.tpl
+++ b/charts/flink-job/templates/_helpers.tpl
@@ -1,0 +1,113 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "flink-job.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "flink-job.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flink-job.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Builds the image identifier with either sha or tag
+*/}}
+{{- define "flink-job.image" -}}
+{{- $repository := coalesce .Values.global.image.repository .Values.image.repository }}
+{{- if .Values.image.sha }}
+{{- printf "%s@sha256:%s" $repository .Values.image.sha }}
+{{- else }}
+{{- printf "%s:%s" $repository (.Values.image.tag | toString) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "flink-job.labels" -}}
+helm.sh/chart: {{ include "flink-job.chart" . }}
+{{ include "flink-job.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "flink-job.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flink-job.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the FlinkDeployment resource
+Needed to make sure that resource names does not surpass the character requirements
+*/}}
+{{- define "flink-job.flinkDeploymentName" -}}
+{{ include "flink-job.fullname" . | trunc 45 }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "flink-job.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "flink-job.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Backstage labels
+*/}}
+{{- define "flink-job.backstageLabels" -}}
+backstage.io/kubernetes-id: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Get the savepoint directories
+*/}}
+{{- define "flink-job.storage-configuration" -}}
+{{ $prefix := (include "flink-job.storage-prefix" . ) }}
+{{ $fullname := (include "flink-job.fullname" . ) }}
+{{- if not (hasKey .Values.flink.configuration "state.savepoints.dir" ) }}
+state.savepoints.dir: {{ printf "%s://flink/%s/savepoints" $prefix $fullname }}
+{{- end }}
+{{- if not (hasKey .Values.flink.configuration "state.checkpoints.dir" ) }}
+state.savepoints.dir: {{ printf "%s://flink/%s/checkpoints" $prefix $fullname }}
+{{- end }}
+{{- if not (hasKey .Values.flink.configuration "high-availability.storageDir" ) }}
+state.savepoints.dir: {{ printf "%s://flink/%s/ha" $prefix $fullname }}
+{{- end }}
+{{- end -}}
+
+{{- define "flink-job.storage-prefix" -}}
+{{- if .Values.flink.s3.enabled }}
+s3p
+{{- else }}
+file
+{{- end }}
+{{- end -}}
+

--- a/charts/flink-job/templates/_helpers.tpl
+++ b/charts/flink-job/templates/_helpers.tpl
@@ -61,6 +61,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+Pod labels
+*/}}
+{{- define "flink-job.podLabels" -}}
+app.kubernetes.io/component: metrics
+{{ include "flink-job.labels" . }}
+{{ include "flink-job.backstageLabels" . }}
+{{ with .Values.metrics.podMonitor.selectors -}}
+  {{- toYaml . }}
+{{- end }}
+{{ with .Values.podLabels -}}
+  {{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the name of the FlinkDeployment resource
 Needed to make sure that resource names does not surpass the character requirements
 */}}

--- a/charts/flink-job/templates/_helpers.tpl
+++ b/charts/flink-job/templates/_helpers.tpl
@@ -159,7 +159,7 @@ Add necessary configuration for running in HA mode
   {{- if gt (int .global.jobManager.replicas) 1 -}}
     {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "high-availability" "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory")) -}}
     {{- if and .global.storage.scheme .global.storage.baseDir -}}
-      {{- $haDir := printf "%s://%s/%s/ha" .global.storage.scheme .global.storage.baseDir .fullname -}}
+      {{- $haDir := printf "%s://%s/%s/ha" (trimSuffix "://" .global.storage.scheme) .global.storage.baseDir .fullname -}}
       {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "high-availability.storageDir" $haDir)) -}}
     {{- end -}}
     {{- if not (hasKey $configs "high-availability.storageDir") -}}
@@ -179,8 +179,8 @@ Validate the configuration
   {{- end -}}
   {{- if has .global.job.upgradeMode (list "savepoint" "last-state") -}}
     {{- if and .global.storage.scheme .global.storage.baseDir -}}
-      {{- $savepointsDir := printf "%s://%s/%s/savepoints" .global.storage.scheme .global.storage.baseDir .fullname -}}
-      {{- $checkpointsDir := printf "%s://%s/%s/checkpoints" .global.storage.scheme .global.storage.baseDir .fullname -}}
+      {{- $savepointsDir := printf "%s://%s/%s/savepoints" (trimSuffix "://" .global.storage.scheme) .global.storage.baseDir .fullname -}}
+      {{- $checkpointsDir := printf "%s://%s/%s/checkpoints" (trimSuffix "://" .global.storage.scheme) .global.storage.baseDir .fullname -}}
       {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "state.savepoints.dir" $savepointsDir)) -}}
       {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "state.checkpoints.dir" $checkpointsDir)) -}}
     {{- end -}}

--- a/charts/flink-job/templates/flink-deployment.yaml
+++ b/charts/flink-job/templates/flink-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
@@ -21,29 +22,8 @@ spec:
   {{- end }}
 
   flinkConfiguration:
-    {{- toYaml .Values.flinkConfiguration | nindent 4 -}}
-    {{/* TODO
-    {{- include "flink-job.storage-configuration" . | nindent 4 -}}
-    {{- include "flink-job.metrics-configuration" . | nindent 4 -}}
-      state.savepoints.dir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "savepoints") }}
-      state.checkpoints.dir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "checkpoints") }}
-      high-availability.storageDir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "ha") }}
-      {{- with .Values.flink.s3 }}
-      s3.path-style-access: {{ .pathStyleAccess | quote }}
-      s3.endpoint: {{ .endpoint | quote }}
-      {{- end }}
-      {{- toYaml .Values.flink.configuration | nindent 4 }}
-    {{ if .Values.monitoring.enabled }}
-      {{- if eq "v1_15" .Values.flink.version }}
-      metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
-      {{- else if eq "v1_16" .Values.flink.version }}
-      metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
-      {{- end }}
-      {{- with .Values.monitoring.flinkProperties }}
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
-    {{- end }}
-    */}}
+    {{- include "flink-job.calculateConfigurations" . | nindent 4 -}}
+
   {{- with .Values.podTemplate }}
   podTemplate:
     {{- tpl . $ | nindent 4 -}}

--- a/charts/flink-job/templates/flink-deployment.yaml
+++ b/charts/flink-job/templates/flink-deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: {{ include "flink-job.flinkDeploymentName" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+spec:
+  image: {{ include "flink-job.image" . | quote }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  serviceAccount: {{ include "flink-job.serviceAccountName" . }}
+  flinkVersion: {{ .Values.version | quote }}
+  {{- with .Values.restartNonce }}
+  restartNonce: {{ . }}
+  {{- end }}
+  {{- with .Values.logConfiguration }}
+  logConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.mode }}
+  mode: {{ . }}
+  {{- end }}
+
+  flinkConfiguration:
+    {{- toYaml .Values.flinkConfiguration | nindent 4 -}}
+    {{/* TODO
+    {{- include "flink-job.storage-configuration" . | nindent 4 -}}
+    {{- include "flink-job.metrics-configuration" . | nindent 4 -}}
+      state.savepoints.dir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "savepoints") }}
+      state.checkpoints.dir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "checkpoints") }}
+      high-availability.storageDir: {{ include "cheetah-flink-native.s3Dir" (dict "context" . "dir" "ha") }}
+      {{- with .Values.flink.s3 }}
+      s3.path-style-access: {{ .pathStyleAccess | quote }}
+      s3.endpoint: {{ .endpoint | quote }}
+      {{- end }}
+      {{- toYaml .Values.flink.configuration | nindent 4 }}
+    {{ if .Values.monitoring.enabled }}
+      {{- if eq "v1_15" .Values.flink.version }}
+      metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+      {{- else if eq "v1_16" .Values.flink.version }}
+      metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+      {{- end }}
+      {{- with .Values.monitoring.flinkProperties }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+    */}}
+  {{- with .Values.podTemplate }}
+  podTemplate:
+    {{- tpl . $ | nindent 4 -}}
+  {{- end }}
+  job:
+    jarURI: {{ .Values.job.jarURI | quote }}
+    {{- with .Values.job.entryClass }}
+    entryClass: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.job.args }}
+    args:
+      {{- range . }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    parallelism: {{ int .Values.job.parallelism }}
+    state: {{ .Values.job.state }}
+    {{- with .Values.job.savepointTriggerNonce }}
+    savepointTriggerNonce: {{ . }}
+    {{- end }}
+    {{- with .Values.job.initialSavepointPath }}
+    initialSavepointPath: {{ . }}
+    {{- end }}
+    {{- with .Values.job.allowNonRestoredState }}
+    allowNonRestoredState: {{ . }}
+    {{- end }}
+    upgradeMode: {{ .Values.job.upgradeMode | quote }}
+
+  jobManager:
+    replicas: {{ int .Values.jobManager.replicas }}
+    resource:
+      {{- toYaml .Values.jobManager.resource | nindent 6 }}
+    {{- with .Values.jobManager.podTemplate }}
+    podTemplate:
+      {{- tpl . $ | nindent 6 -}}
+    {{- end }}
+
+  taskManager:
+    replicas: {{ int .Values.taskManager.replicas }}
+    resource:
+      {{- toYaml .Values.taskManager.resource | nindent 6 }}
+    {{- with .Values.taskManager.podTemplate }}
+    podTemplate:
+      {{- tpl . $ | nindent 6 -}}
+    {{- end }}

--- a/charts/flink-job/templates/flink-deployment.yaml
+++ b/charts/flink-job/templates/flink-deployment.yaml
@@ -33,9 +33,15 @@ spec:
     {{- with .Values.job.entryClass }}
     entryClass: {{ . | quote }}
     {{- end }}
-    {{- with .Values.job.args }}
+    {{- if or .Values.job.args .Values.job.topics }}
     args:
-      {{- range . }}
+      {{- range .Values.job.topics }}
+        {{- if .arg }}
+        - {{ printf "--%s" .arg | quote }}
+        - {{ printf "%s" .name | quote }}
+        {{- end }}
+      {{- end }}
+      {{- range .Values.job.args }}
       - {{ . | quote }}
       {{- end }}
     {{- end }}

--- a/charts/flink-job/templates/flink-deployment.yaml
+++ b/charts/flink-job/templates/flink-deployment.yaml
@@ -37,7 +37,7 @@ spec:
     args:
       {{- range .Values.job.topics }}
         {{- if .arg }}
-        - {{ printf "--%s" .arg | quote }}
+        - {{ printf "--%s" (trimPrefix "--" .arg) | quote }}
         - {{ printf "%s" .name | quote }}
         {{- end }}
       {{- end }}

--- a/charts/flink-job/templates/flink-deployment.yaml
+++ b/charts/flink-job/templates/flink-deployment.yaml
@@ -36,10 +36,10 @@ spec:
     {{- if or .Values.job.args .Values.job.topics }}
     args:
       {{- range .Values.job.topics }}
-        {{- if .arg }}
-        - {{ printf "--%s" (trimPrefix "--" .arg) | quote }}
-        - {{ printf "%s" .name | quote }}
-        {{- end }}
+      {{- if .arg }}
+      - {{ printf "--%s" (trimPrefix "--" .arg) | quote }}
+      - {{ printf "%s" .name | quote }}
+      {{- end }}
       {{- end }}
       {{- range .Values.job.args }}
       - {{ . | quote }}

--- a/charts/flink-job/templates/ingress.yaml
+++ b/charts/flink-job/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "flink-job.fullname" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            pathType: {{ .Values.ingress.pathType | quote }}
+            backend:
+              service:
+                name: {{ include "flink-job.flinkDeploymentName" . }}-rest
+                port:
+                  number: {{ int .Values.ingress.uiPort }}
+  {{- if or .Values.ingress.tlsSecret .Values.ingress.selfSigned }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ .Values.ingress.tlsSecret | default (printf "%s-tls" .Values.ingress.hostname) | quote }}
+  {{- end }}
+{{- end -}}

--- a/charts/flink-job/templates/podmonitor.yaml
+++ b/charts/flink-job/templates/podmonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "flink-job.fullname" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      {{- with .Values.metrics.podMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.metrics.podMonitor.extraMetricsEndpoints }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  podTargetLabels:
+    {{- toYaml .Values.metrics.podMonitor.targetLabels | nindent 4 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics
+      {{- include "flink-job.selectorLabels" . | nindent 6 }}
+      {{- with .Values.metrics.podMonitor.selectors }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end -}}

--- a/charts/flink-job/templates/rbac.yaml
+++ b/charts/flink-job/templates/rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "flink-job.fullname" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - '*'
+{{- with .Values.rbac.additionalRules }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "flink-job.fullname" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "flink-job.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "flink-job.serviceAccountName" . }}
+{{- end -}}

--- a/charts/flink-job/templates/secret.yaml
+++ b/charts/flink-job/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ingress.selfSigned -}}
+{{- $ca := genCA "flink-job-ca" 365 -}}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname | quote }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end -}}

--- a/charts/flink-job/templates/serviceaccount.yaml
+++ b/charts/flink-job/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flink-job.serviceAccountName" . }}
+  labels:
+    {{- include "flink-job.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -30,7 +30,6 @@ version: v1_15
 # For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/>
 flinkConfiguration:
   state.backend: "hashmap"
-  high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
   execution.checkpointing.interval: "10 minutes"
   execution.checkpointing.min-pause: "10 minutes"
   execution.checkpointing.timeout: "5 minutes"
@@ -38,8 +37,6 @@ flinkConfiguration:
   taskmanager.numberOfTaskSlots: "2"
   kubernetes.taskmanager.cpu.limit-factor: "10.0"
   kubernetes.jobmanager.cpu.limit-factor: "10.0"
-  # metrics.reporters: prom
-  # metrics.reporter.prom.port: "9249"
 
 # -- change this to force a restart of the job,
 # see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info
@@ -49,6 +46,16 @@ logConfiguration: {}
 # -- Cluster deployment mode. Support values are `native` and `standalone`
 # `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes
 mode: native
+
+storage:
+  # -- File storage scheme.
+  # Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/)
+  # To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc.
+  # (Note the exclusion of `://`)
+  scheme: ""
+  # -- Set the base directory for the HA, savepoints, and checkpoints storage.
+  # Generates a directory tree, based on the file system scheme, base directory, release name, and storage type
+  baseDir: ""
 
 # -- Extra ports to open on both job- and task-manager
 ports: []
@@ -127,32 +134,7 @@ podTemplate: |-
       - name: flink-main-container
         securityContext:
           {{- toYaml .Values.securityContext | nindent 8 }}
-        {{- with .Values.env }}
-        env:
-          {{- toYaml . | nindent 8 -}}
-        {{- end }}
-        {{- with .Values.envFrom }}
-        envFrom:
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        ports:
-          {{- with .Values.ports }}
-          {{- toYaml . | nindent 8 -}}
-          {{- end }}
-          {{- if .Values.metrics.enabled }}
-          - name: metrics
-            containerPort: {{ .Values.metrics.port }}
-          {{- end }}
-        {{- with .Values.volumeMounts }}
-        volumeMounts:
-          {{- toYaml . | nindent 8 -}}
-        {{- end }}
-    {{- with .Values.volumes }}
-    volumes:
-      {{- toYaml . | nindent 4 -}}
-    {{- end }}
-    {{ $imagepullsecrets := coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets }}
-    {{- with $imagepullsecrets -}}
+    {{- with (coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets) }}
     imagePullSecrets:
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -181,8 +163,6 @@ taskManager:
   # -- Additional annotations attached to the pods
   podAnnotations: {}
 
-  # TODO: figure out if specifying an extra port overrides `.podTemplate`
-
   # -- Pod template. Overrides the main `podTemplate`.
   # The main flink-container must be called "flink-main-container"
   # @default -- (see values.yaml)
@@ -199,23 +179,27 @@ taskManager:
     spec:
       containers:
         - name: flink-main-container
-          {{- with .Values.taskManager.ports }}
           ports:
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+          {{- with (concat .Values.ports .Values.taskManager.ports) }}
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.taskManager.env }}
+          {{- with (concat .Values.env .Values.taskManager.env) }}
           env:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.taskManager.envFrom }}
+          {{- with (concat .Values.envFrom .Values.taskManager.envFrom) }}
           envFrom:
-            {{- toYaml . | nindent 8 -}}
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-          {{- with .Values.taskManager.volumeMounts }}
+          {{- with (concat .Values.volumeMounts .Values.taskManager.volumeMounts) }}
           volumeMounts:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-      {{- with .Values.taskManager.volumes }}
+      {{- with (concat .Values.volumes .Values.taskManager.volumes) }}
       volumes:
         {{- toYaml . | nindent 4 -}}
       {{- end }}
@@ -244,8 +228,6 @@ jobManager:
   # -- Additional annotations attached to the pods
   podAnnotations: {}
 
-  # TODO: figure out if specifying an extra port overrides `.podTemplate`
-
   # -- Pod template. Overrides the main `podTemplate`.
   # The main flink-container must be called "flink-main-container"
   # @default -- (see values.yaml)
@@ -263,24 +245,26 @@ jobManager:
       containers:
         - name: flink-main-container
           ports:
-            - name: ui
-              containerPort: {{ .Values.ingress.uiPort }}
-              {{- with .Values.jobManager.ports }}
-              {{- toYaml . | nindent 8 -}}
-              {{- end }}
-          {{- with .Values.jobManager.env }}
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+          {{- with (concat .Values.ports .Values.jobManager.ports) }}
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with (concat .Values.env .Values.jobManager.env) }}
           env:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-          {{- with .Values.jobManager.envFrom }}
+          {{- with (concat .Values.envFrom .Values.jobManager.envFrom) }}
           envFrom:
-            {{- toYaml . | nindent 8 -}}
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-          {{- with .Values.jobManager.volumeMounts }}
+          {{- with (concat .Values.volumeMounts .Values.jobManager.volumeMounts) }}
           volumeMounts:
             {{- toYaml . | nindent 8 -}}
           {{- end }}
-      {{- with .Values.jobManager.volumes }}
+      {{- with (concat .Values.volumes .Values.jobManager.volumes) }}
       volumes:
         {{- toYaml . | nindent 4 -}}
       {{- end }}

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -132,15 +132,7 @@ job:
 podTemplate: |-
   metadata:
     labels:
-      app.kubernetes.io/component: metrics
-      {{- include "flink-job.backstageLabels" . | nindent 4 }}
-      {{- include "flink-job.selectorLabels" . | nindent 4 }}
-      {{- with .Values.metrics.podMonitor.selectors }}
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
-      {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
+      {{- include "flink-job.podLabels" . | nindent 4 }}
     {{- with .Values.podAnnotations }}
     annotations:
       {{- toYaml . | nindent 4 }}

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -24,7 +24,7 @@ image:
 imagePullSecrets: []
 
 # -- Which Flink version to use
-version: v1_15
+version: v1_16
 
 # -- Flink configuration
 # For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/>

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -1,0 +1,383 @@
+# Default values for flink-job.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Only used to decrease duplicate configuration of this chart, if image-automation is used as a sub chart.
+# Overrides the local values if given
+global:
+  image:
+    repository: ""
+  imagePullSecrets: []
+
+image:
+  # -- Which image repository to use
+  repository: flink
+  # -- Which image tag to use
+  tag: main
+  # -- Which image sha to use. If used, the `image.tag` is ignored
+  sha: ""
+  # -- Which image pull policy to use
+  pullPolicy: Always
+
+# -- Image pull secrets. A list of `name: <secret-name>`
+imagePullSecrets: []
+
+# -- Which Flink version to use
+version: v1_15
+
+# -- Flink configuration
+# For metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/>
+flinkConfiguration:
+  state.backend: "hashmap"
+  high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+  execution.checkpointing.interval: "10 minutes"
+  execution.checkpointing.min-pause: "10 minutes"
+  execution.checkpointing.timeout: "5 minutes"
+  rest.flamegraph.enabled: "true"
+  taskmanager.numberOfTaskSlots: "2"
+  kubernetes.taskmanager.cpu.limit-factor: "10.0"
+  kubernetes.jobmanager.cpu.limit-factor: "10.0"
+  # metrics.reporters: prom
+  # metrics.reporter.prom.port: "9249"
+
+# -- change this to force a restart of the job,
+# see <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/> for more info
+restartNonce: 0
+# -- Custom logging configuration
+logConfiguration: {}
+# -- Cluster deployment mode. Support values are `native` and `standalone`
+# `native` is the recommended mode, as this makes Flink aware of it running on Kubernetes
+mode: native
+
+# -- Extra ports to open on both job- and task-manager
+ports: []
+# -- Extra environment variables to set on both job- and task-manager
+env: []
+# -- List of ConfigMap/Secrets where environment variables can be loaded from
+envFrom: []
+# -- List of additional volumes for the both job- and task-manager
+volumes: []
+# -- List of additional volume mounts for the both job- and task-manager
+volumeMounts: []
+# -- Additional labels attached to the pods
+podLabels: {}
+# -- Additional annotations attached to the pods
+podAnnotations: {}
+
+job:
+  # -- The path of the job jar
+  jarURI: ""
+  # -- The name of the job class
+  entryClass: ""
+  # -- Arguments for the job
+  args: []
+
+  # -- How many jobs to run in parallel,
+  # see more here: <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/execution/parallel/>
+  parallelism: 2
+
+  # -- Desired state of the job.
+  # Must be either: `running` or `suspended`
+  state: running
+
+  # -- Application upgrade mode. Must be either: stateless, last_state, savepoint
+  # `stateless` upgrades is done from an empty state
+  # `last-state` does a quick upgrade. Does not require the job to be in a healthy state
+  # `savepoint` makes use of savepoints when upgrading and requires the job to be running.
+  # This provides maximal safety
+  # Read more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/#stateful-and-stateless-application-upgrades>
+  upgradeMode: "savepoint"
+
+  # -- change this to trigger a savepoint manually,
+  # see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/>
+  savepointTriggerNonce: 0
+
+  # -- change this to force a manual recovery checkpoint,
+  # see more here: <https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/job-management/>
+  initialSavepointPath: ""
+
+  # -- If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed.
+  allowNonRestoredState: false
+
+# -- Shared job-/task-manager pod template.
+# Overridden by `(job/task)Manager.podTemplate`.
+# The main flink-container must be called "flink-main-container"
+# @default -- (see values.yaml)
+podTemplate: |-
+  metadata:
+    labels:
+      app.kubernetes.io/component: metrics
+      {{- include "flink-job.backstageLabels" . | nindent 4 }}
+      {{- include "flink-job.selectorLabels" . | nindent 4 }}
+      {{- with .Values.metrics.podMonitor.selectors }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- with .Values.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  spec:
+    securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 4 }}
+    containers:
+      - name: flink-main-container
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- with .Values.env }}
+        env:
+          {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        ports:
+          {{- with .Values.ports }}
+          {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+          - name: metrics
+            containerPort: {{ .Values.metrics.port }}
+          {{- end }}
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 8 -}}
+        {{- end }}
+    {{- with .Values.volumes }}
+    volumes:
+      {{- toYaml . | nindent 4 -}}
+    {{- end }}
+    {{ $imagepullsecrets := coalesce .Values.global.imagePullSecrets .Values.imagePullSecrets }}
+    {{- with $imagepullsecrets -}}
+    imagePullSecrets:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+
+taskManager:
+  # -- Number of replicas
+  replicas: 1
+  resource:
+    # -- Memory to reserve for each Task Manager. The amount needed depends on the amount of data to be processed by each Task Manager, and how much state it should store in memory.
+    memory: 1Gb
+    # -- CPU requests.
+    # CPU limits is CPU requests multiplied by flinkConfiguration."kubernetes.jobmanager.cpu.limit-factor"
+    cpu: 0.1
+  # -- Extra ports to open
+  ports: []
+  # -- Extra environment variables
+  env: []
+  # -- List of ConfigMap/Secrets where environment variables can be loaded from
+  envFrom: []
+  # -- List of additional volumes
+  volumes: []
+  # -- List of additional volume mounts
+  volumeMounts: []
+  # -- Additional labels attached to the pods
+  podLabels: {}
+  # -- Additional annotations attached to the pods
+  podAnnotations: {}
+
+  # TODO: figure out if specifying an extra port overrides `.podTemplate`
+
+  # -- Pod template. Overrides the main `podTemplate`.
+  # The main flink-container must be called "flink-main-container"
+  # @default -- (see values.yaml)
+  podTemplate: |-
+    metadata:
+      {{- with .Values.taskManager.podLabels }}
+      labels:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.taskManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: flink-main-container
+          {{- with .Values.taskManager.ports }}
+          ports:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.env }}
+          env:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.taskManager.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+      {{- with .Values.taskManager.volumes }}
+      volumes:
+        {{- toYaml . | nindent 4 -}}
+      {{- end }}
+
+jobManager:
+  # -- Number of replicas
+  replicas: 1
+  resource:
+    # -- Memory to reserve for the Job Manager. The default value should be ok for most jobs.
+    memory: 1Gb
+    # -- CPU requests.
+    # CPU limits is CPU requests multiplied by flinkConfiguration."kubernetes.jobmanager.cpu.limit-factor"
+    cpu: 0.1
+  # -- Extra ports to open
+  ports: []
+  # -- Extra environment variables
+  env: []
+  # -- List of ConfigMap/Secrets where environment variables can be loaded from
+  envFrom: []
+  # -- List of additional volumes
+  volumes: []
+  # -- List of additional volume mounts
+  volumeMounts: []
+  # -- Additional labels attached to the pods
+  podLabels: {}
+  # -- Additional annotations attached to the pods
+  podAnnotations: {}
+
+  # TODO: figure out if specifying an extra port overrides `.podTemplate`
+
+  # -- Pod template. Overrides the main `podTemplate`.
+  # The main flink-container must be called "flink-main-container"
+  # @default -- (see values.yaml)
+  podTemplate: |-
+    metadata:
+      {{- with .Values.jobManager.podLabels }}
+      labels:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.jobManager.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: flink-main-container
+          ports:
+            - name: ui
+              containerPort: {{ .Values.ingress.uiPort }}
+              {{- with .Values.jobManager.ports }}
+              {{- toYaml . | nindent 8 -}}
+              {{- end }}
+          {{- with .Values.jobManager.env }}
+          env:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.jobManager.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+          {{- with .Values.jobManager.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 8 -}}
+          {{- end }}
+      {{- with .Values.jobManager.volumes }}
+      volumes:
+        {{- toYaml . | nindent 4 -}}
+      {{- end }}
+
+metrics:
+  # -- Enable metrics scraping. Define flinkProperties to define the monitoring properties
+  enabled: true
+
+  # -- Port on both job- and task-manager where metrics are exposed
+  port: 9249
+
+  podMonitor:
+    enabled: true
+    # -- Override the metrics scrape path
+    path: ""
+    # -- Override the default scrape interval
+    interval: ""
+    # -- Override the default scrape timeout
+    scrapeTimeout: ""
+    # -- MetricRelabelConfigs to apply to samples before ingestion
+    metricRelabelings: []
+    # -- RelabelConfigs to apply to samples before scraping
+    relabelings: []
+    # -- Extra pod selector labels
+    selectors: {}
+    # -- Extra PodMonitor labels
+    labels: {}
+    # -- Extra podmonitor metrics endpoints
+    extraMetricsEndpoints: []
+    # -- Copy pod labels onto the metrics targets
+    targetLabels:
+      - component
+      - cluster
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # -- Auto-mount service account tokens
+  automountServiceAccountToken: true
+
+rbac:
+  # -- Specifies whether a Role and RoleBinding should be created
+  create: true
+  # -- Additional rules to add to the role
+  additionalRules: []
+
+# Default pod security context
+podSecurityContext:
+  # -- Whether to run the pod without root capabilities
+  runAsNonRoot: true
+  # -- Add a supplimentary group ID to all processes in the container. Set the owner of all volumes to this group
+  fsGroup: 9999
+  seccompProfile:
+    # -- Which secure computing mode (seccomp) profile to use
+    type: RuntimeDefault
+
+# Default container security context
+securityContext:
+  # -- Allow privilege escalation
+  allowPrivilegeEscalation: false
+  # -- User to run the container as
+  runAsGroup: 9999
+  # -- Group to add the user to
+  runAsUser: 9999
+  capabilities:
+    # -- Linux capabilities to drop
+    drop:
+      - ALL
+    # -- Linux capabilities to add
+    add: []
+
+ingress:
+  # -- Whether to expose the Flink UI, on the job-manager
+  enabled: false
+  # -- Flink UI port. Ingress will hit the service on this port
+  uiPort: 8081
+  # -- Ingress controller name
+  ingressClassName: ""
+  # -- Which host name to use for the Flink UI
+  hostname: flink.cheetah.trifork.dev
+  # -- Which subpath to expose the Flink UI under
+  path: /
+  # -- Which path type to use
+  pathType: ImplementationSpecific
+  # -- Extra Ingress annotations
+  annotations: {}
+  # -- Add TLS certificates from an existing secret
+  tlsSecret: ""
+  # -- Create a self-signed TLS secret
+  selfSigned: false
+
+# -- Settings passed to the image-automation chart,
+# Image-automation is not possible when using image-sha as a tagging strategy
+image-automation:
+  enabled: false

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -107,6 +107,25 @@ job:
   # -- If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed.
   allowNonRestoredState: false
 
+  # -- Define which topics this job will consume.
+  # Used for data-discovery in Cheetah Backstage.
+  # If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job
+  # See `values.yaml` for the format
+  topics: []
+  # must be defined as follows
+  # - arg: <optional name of argument>
+  #   type: <type of topic (input/output)>
+  #   name: <name of topic>
+  # ie:
+  # - type: input
+  #   name: defaultIngest
+  # - arg: input-kafka-topic
+  #   type: input
+  #   name: sourceTopic
+  # - arg: output-kafka-topic
+  #   type: output
+  #   name: sinkTopic
+
 # -- Shared job-/task-manager pod template.
 # Overridden by `(job/task)Manager.podTemplate`.
 # The main flink-container must be called "flink-main-container"

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -54,7 +54,7 @@ storage:
   # (Note the exclusion of `://`)
   scheme: ""
   # -- Set the base directory for the HA, savepoints, and checkpoints storage.
-  # Generates a directory tree, based on the file system scheme, base directory, release name, and storage type
+  # Generates a directory tree, based on the file system scheme, base directory, release name, and storage type (savepoint, checkpoint, or HA metadata)
   baseDir: ""
 
 # -- Extra ports to open on both job- and task-manager

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -79,6 +79,24 @@ job:
   entryClass: ""
   # -- Arguments for the job
   args: []
+  # -- Define which topics this job will consume.
+  # Used for data-discovery in Cheetah Backstage.
+  # If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job
+  # See `values.yaml` for the format
+  topics: []
+  # must be defined as follows
+  # - arg: <optional name of argument>
+  #   type: <type of topic (input/output)>
+  #   name: <name of topic>
+  # ie:
+  # - type: input
+  #   name: defaultIngest
+  # - arg: input-kafka-topic
+  #   type: input
+  #   name: sourceTopic
+  # - arg: output-kafka-topic
+  #   type: output
+  #   name: sinkTopic
 
   # -- How many jobs to run in parallel,
   # see more here: <https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/execution/parallel/>
@@ -106,25 +124,6 @@ job:
 
   # -- If this is true, it will ignore the past checkpoints and start anew. Usefull if the job schema has changed.
   allowNonRestoredState: false
-
-  # -- Define which topics this job will consume.
-  # Used for data-discovery in Cheetah Backstage.
-  # If the `arg` variable is set, adds `--<arg> <name>` to the arguments passed to the job
-  # See `values.yaml` for the format
-  topics: []
-  # must be defined as follows
-  # - arg: <optional name of argument>
-  #   type: <type of topic (input/output)>
-  #   name: <name of topic>
-  # ie:
-  # - type: input
-  #   name: defaultIngest
-  # - arg: input-kafka-topic
-  #   type: input
-  #   name: sourceTopic
-  # - arg: output-kafka-topic
-  #   type: output
-  #   name: sinkTopic
 
 # -- Shared job-/task-manager pod template.
 # Overridden by `(job/task)Manager.podTemplate`.

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -51,7 +51,6 @@ storage:
   # -- File storage scheme.
   # Allowed values follows supported URI schemes, as explained [here](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/)
   # To use S3 storage set `scheme=s3`, to use local file-system use `scheme=file`, etc.
-  # (Note the exclusion of `://`)
   scheme: ""
   # -- Set the base directory for the HA, savepoints, and checkpoints storage.
   # Generates a directory tree, based on the file system scheme, base directory, release name, and storage type (savepoint, checkpoint, or HA metadata)


### PR DESCRIPTION
Instead of trying to fix the existing Flink chart, we have elected to create a new, and deprecate the old "cheetah-flink-native" chart.
Meanwhile, we will make the values spec closer to the Kubernetes resources, such as the `FlinkDeployment` resource.

New chart requirements:

- [x] Rename to "flink-job"
- [x] Remove assumptions to how secrets are injected
- [x] Remove assumptions on the ingress controller
- [x] Remove kubernetes-replicator dependency
- [x] Figure out which configuration in `podTemplate` is overwritten by `xxxManager.podTemplate`
- [x] Smart configuration of Flink configuration
  - [x] Metrics
  - [x] Savepointing/checkpointing
  - [x] HA
- [x] Better documentation