### PR TITLE
JSON schema for opensearch

### DIFF
--- a/charts/opensearchrole/Chart.yaml
+++ b/charts/opensearchrole/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0

--- a/charts/opensearchrole/README.md
+++ b/charts/opensearchrole/README.md
@@ -1,6 +1,6 @@
 # opensearchrole
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for creating opensearch roles with both read and write permissions based on a given index name.
 

--- a/charts/opensearchrole/values.schema.json
+++ b/charts/opensearchrole/values.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for opensearchrole/values.yaml",
+  "type": "object",
+  "properties": {
+    "roleNamePrefix": {
+      "type": "string"
+    },
+    "roleName": {
+      "type": "string"
+    },
+    "indexPattern": {
+      "type": "string"
+    },
+    "clusterName": {
+      "type": "string"
+    }
+  },
+  "required": []
+}

--- a/charts/opensearchrole/values.schema.json
+++ b/charts/opensearchrole/values.schema.json
@@ -16,5 +16,8 @@
       "type": "string"
     }
   },
-  "required": []
+  "required": [
+    "clusterName",
+    "roleName"
+  ]
 }


### PR DESCRIPTION
Add JSON schema for opensearch

Continuation of https://github.com/trifork/cheetah-charts/pull/95
Implementing https://jira.trifork.com/browse/KAMDP-341
Tested with this script:
```sh
kubectl get helmreleases.helm.toolkit.fluxcd.io --all-namespaces -o yaml > releases.tmp
yq '.items | map(select(.spec.chart.spec.chart == "opensearchrole")) | .[].spec.values | split_doc' releases.tmp > filtered.tmp
for i in `seq 0 20` ; do yq "select(di == ${i})" filtered.tmp | yq 'load("values.yaml") *= .' > "${i}.tmp" ; done
for i in `seq 0 20` ; do if [ `cat "${i}.tmp" | wc -l` -gt 1 ] ; then helm lint . --values "${i}.tmp" ; fi ; done

for i in `seq 0 20` ; do rm "${i}.tmp" ; done
rm filtered.tmp
rm releases.tmp
```
There existed only 1 chart and it was linted successfully