### PR TITLE
added secure default algorithms for flink internalSsl

### DIFF
--- a/charts/flink-job/Chart.yaml
+++ b/charts/flink-job/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.6.0
 
 dependencies:
   - name: image-automation

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -1,6 +1,6 @@
 # flink-job
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for handling Cheetah Data Platform Flink jobs
 
@@ -130,6 +130,7 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | imagePullSecrets | list | `[]` | Array of image pull secrets. Each entry follows the `name: <secret-name>` format |
 | version | string | `"v1_16"` | Which Flink version to use |
 | internalSsl.enabled | bool | `true` | Whether to use SSL between the job- and taskmanager |
+| internalSsl.algorithms | string | `"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"` | Set the algorithms alllowed. see also: https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites |
 | internalSsl.certDuration | string | `"26280h"` | What duration to give the certificates provisioned for the internal SSL. Value must be specified using a Go time.Duration string format |
 | internalSsl.certRenewBefore | string | `"2160h"` | When to renew the certificates provisioned for the internal SSL. Value must be specified using a Go time.Duration string format |
 | flinkConfiguration | object | (see [values.yaml](values.yaml)) | Flink configuration For more configuration options, see here: <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/> For specific metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |

--- a/charts/flink-job/README.md
+++ b/charts/flink-job/README.md
@@ -130,7 +130,7 @@ Read more about Flink and highly available job-managers [here](https://nightlies
 | imagePullSecrets | list | `[]` | Array of image pull secrets. Each entry follows the `name: <secret-name>` format |
 | version | string | `"v1_16"` | Which Flink version to use |
 | internalSsl.enabled | bool | `true` | Whether to use SSL between the job- and taskmanager |
-| internalSsl.algorithms | string | `"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"` | Set the algorithms alllowed. see also: https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites |
+| internalSsl.algorithms | string | `"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"` | Set the algorithms allowed. see also: <https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites> |
 | internalSsl.certDuration | string | `"26280h"` | What duration to give the certificates provisioned for the internal SSL. Value must be specified using a Go time.Duration string format |
 | internalSsl.certRenewBefore | string | `"2160h"` | When to renew the certificates provisioned for the internal SSL. Value must be specified using a Go time.Duration string format |
 | flinkConfiguration | object | (see [values.yaml](values.yaml)) | Flink configuration For more configuration options, see here: <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/> For specific metrics configuration, see here:  <https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters/> |

--- a/charts/flink-job/templates/_helpers.tpl
+++ b/charts/flink-job/templates/_helpers.tpl
@@ -197,6 +197,7 @@ Add necessary ssl configuration
   {{- $configs := .configs -}}
   {{- $password := sha1sum (nospace (toString .global.image)) | trunc 10 }}
   {{- if .global.internalSsl.enabled -}}
+    {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "security.ssl.algorithms" (toString .global.internalSsl.algorithms))) -}}
     {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "security.ssl.internal.enabled" "true")) -}}
     {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "security.ssl.internal.keystore" "/flinkkeystore/keystore.jks")) -}}
     {{- $configs = fromJson (include "flink-job._dictSet" (list $configs "security.ssl.internal.truststore" "/flinkkeystore/truststore.jks")) -}}

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -33,8 +33,8 @@ version: v1_16
 internalSsl:
   # -- Whether to use SSL between the job- and taskmanager
   enabled: true
-  # -- Set the algorithms alllowed.
-  # see also: https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites
+  # -- Set the algorithms allowed.
+  # see also: <https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites>
   algorithms: "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
   # -- What duration to give the certificates provisioned for the internal SSL.
   # Value must be specified using a Go time.Duration string format

--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -33,6 +33,9 @@ version: v1_16
 internalSsl:
   # -- Whether to use SSL between the job- and taskmanager
   enabled: true
+  # -- Set the algorithms alllowed.
+  # see also: https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites
+  algorithms: "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
   # -- What duration to give the certificates provisioned for the internal SSL.
   # Value must be specified using a Go time.Duration string format
   certDuration: 26280h


### PR DESCRIPTION
Use the secure ciphers from https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/deployment/security/security-ssl/#cipher-suites by default