### PR TITLE
All root level nodes in JSON disallow arbitrary children nodes

### DIFF
--- a/charts/cheetah-application/values.schema.json
+++ b/charts/cheetah-application/values.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "JSON schema for cheetah-application/values.yaml",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "image",
     "global",

--- a/charts/flink-job/values.schema.json
+++ b/charts/flink-job/values.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "JSON schema for flink-job/values.yaml",
   "type": "object",
+  "additionalProperties": false,
   "allOf": [
     {
       "if": {
@@ -677,6 +678,14 @@
       "properties": {
         "enabled": {
           "description": "Whether to enable the image-automation subchart. Any other configuration given here, is passed to it",
+          "type": "boolean"
+        }
+      }
+    },
+    "localNetworkConfiguration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
           "type": "boolean"
         }
       }

--- a/charts/image-automation/values.schema.json
+++ b/charts/image-automation/values.schema.json
@@ -1,6 +1,8 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "JSON schema for image-automation/values.yaml",
     "type": "object",
+    "additionalProperties": false,
     "required": [
         "image"
     ],

--- a/charts/opensearchrole/values.schema.json
+++ b/charts/opensearchrole/values.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "JSON schema for opensearchrole/values.yaml",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "roleNamePrefix": {
       "type": "string"


### PR DESCRIPTION
Make all root nodes of the json schema disallow arbitrary children values to prevent schema drift.
https://jira.trifork.com/browse/KAMDP-978