### PR TITLE
Change default logging to use JsonTemplateLayout

### DIFF
--- a/charts/flink-job/values.yaml
+++ b/charts/flink-job/values.yaml
@@ -74,8 +74,46 @@ logConfiguration:
     # Log all infos to the console
     appender.console.name = ConsoleAppender
     appender.console.type = CONSOLE
-    appender.console.layout.type = PatternLayout
-    appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+    appender.console.layout.type = JsonTemplateLayout
+
+    # Adapted from https://github.com/apache/logging-log4j2/blob/main/log4j-layout-template-json/src/main/resources/GelfLayout.json
+    appender.console.layout.eventTemplate = {\
+      "Host": "${hostName}",\
+      "Message": {\
+        "$resolver": "message",\
+        "stringified": true\
+      },\
+      "Exception": {\
+        "$resolver": "exception",\
+        "field": "stackTrace",\
+        "stackTrace": {\
+          "stringified": true\
+        }\
+      },\
+      "Timestamp": {\
+        "$resolver": "timestamp"\
+      },\
+      "Level": {\
+        "$resolver": "pattern",\
+        "pattern": "%level{INFO=Information, DEBUG=Debug, ERROR=Error, WARN=Warning, TRACE=Trace}"\
+      },\
+      "_logger": {\
+        "$resolver": "logger",\
+        "field": "name"\
+      },\
+      "_thread": {\
+        "$resolver": "thread",\
+        "field": "name"\
+      },\
+      "_mdc": {\
+        "$resolver": "mdc",\
+        "flatten": {\
+          "prefix": "_"\
+        },\
+        "stringified": true\
+      }\
+    }
 
     # Suppress the irrelevant (wrong) warnings from the Netty channel handler
     logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline


### PR DESCRIPTION
This is a breaking change since it requires 
org.apache.logging.log4j:log4j-layout-template-json
to be on the classpath
This can be achived by adding the following to your runtime layer in your Dockerfile:

```
# Add support for structured JSON logging
RUN log4jVersion=$(ls /opt/flink/lib/log4j-core-*.jar | grep -oP '(\d+\.\d+\.\d+)') && \
    wget -P /opt/flink/lib https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-layout-template-json/$log4jVersion/log4j-layout-template-json-$log4jVersion.jar
```