### PR TITLE
Add instructions how to lint charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,16 @@ cd charts/flink-job
 helm lint . --values ci/example-values.yaml
 ```
 
-To lint the charts on the cluster, you can use the `lintchart.sh` script in the root of this repository.
-e.g.:
-```bash
-./lintchart.sh flink-job 20
-```
 
 To run linting on your local machine, use `make lint` at the root of this repository.
 This will make use of [`ct`](https://github.com/helm/chart-testing) - a CLI for linting and testing on a running Kubernetes cluster.
+
+Alternatively, if you require more fine-grained local linting, you can check the script `lintchart.sh`
+It is setup to lint the charts on the cluster but can be edited to suit local development.
+Example usage (identical to `make lint` but for 1 directory only):
+```bash
+./lintchart.sh flink-job 20
+```
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,25 @@ choco install make
 
 If you have docker installed on your system, the make commands will run inside docker, if you do not, they will require [`ct`](https://github.com/helm/chart-testing) and [`helm-docs`](https://github.com/norwoodj/helm-docs) for linting and docs generation, respectively.
 
-### Linting and Docs
+### Linting
+
+To lint a single chart you enter the directory of the chart and run `helm lint`.
+You can provide a file with values to test against. e.g.:
+```bash
+cd charts/flink-job
+helm lint . --values ci/example-values.yaml
+```
+
+To lint the charts on the cluster, you can use the `lintchart.sh` script in the root of this repository.
+e.g.:
+```bash
+./lintchart.sh flink-job 20
+```
 
 To run linting on your local machine, use `make lint` at the root of this repository.
 This will make use of [`ct`](https://github.com/helm/chart-testing) - a CLI for linting and testing on a running Kubernetes cluster.
+
+### Docs
 
 To update documentation from your local machine, use `make docs` at the root of this repository.
 This will make use of [`helm-docs`](https://github.com/norwoodj/helm-docs) to generate documentation based in the `values.yaml` file in each chart.

--- a/lintchart.sh
+++ b/lintchart.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script, which fetches the helm releases from the cluster and 
+# lints them against the values.schema.json
+# The script assumes the charts are under the 'charts' directory in the root of this repo
+# The script takes 2 params:
+# <dir-of-json-schema> - directory where the values.schema.json is. e.g., 'flink-job'
+# <max-charts-to-lint> - set an upper limit for the number of charts to lint.
+#
+# Example usage ./lintchart.sh flink-job 20
+
+if [ $# -ne 2 ]; then
+    echo "The script takes 2 parameters <dir-of-json-schema> <max-charts-to-lint>"
+    echo "Example params: flink-job 20"
+fi
+    
+CHART="$1"
+CHART_DIR="charts/${CHART}"
+MAX_CHARTS="$2"
+
+echo "Linting charts in directory ${CHART_DIR} for chart ${CHART}. Will stop after linting at most ${MAX_CHARTS}."
+
+TMP_CUR_DIR=$(pwd)
+cd ${CHART_DIR}
+
+kubectl get helmreleases.helm.toolkit.fluxcd.io --all-namespaces -o yaml |
+yq eval ".items | map(select(.spec.chart.spec.chart == \"${CHART}\")) | .[].spec.values | split_doc" > temp_lint_deleteme.tmp
+for i in `seq 0 ${MAX_CHARTS}` ; do
+    yq "select(di == ${i})" temp_lint_deleteme.tmp | yq 'load("values.yaml") *= .' > "${i}.tmp" ;
+done
+
+for i in `seq 0 ${MAX_CHARTS}` ; do
+    if [ `cat "${i}.tmp" | wc -l` -gt 1 ] ;
+        then helm lint . --values "${i}.tmp" ;
+    fi ;
+done
+
+for i in `seq 0 ${MAX_CHARTS}` ; do rm "${i}.tmp" ; done
+rm temp_lint_deleteme.tmp
+
+cd $TMP_CUR_DIR


### PR DESCRIPTION
Adding instructions to the README how to lint the helm charts using the `values.schema.json`.

Also adding a script `lintchart.sh`, which fetches all the charts from the cluster for a given chart name,
merges them with the values.yaml and lints them using the `values.schema.json`.
