### PR TITLE
Add _helpers.tpl for oauth2proxy configuration

### DIFF
--- a/charts/redpanda-console-oauth2proxy/Chart.yaml
+++ b/charts/redpanda-console-oauth2proxy/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 1.1.0
+version: 0.1.0
 
 # The app version is the version of the Chart application
 appVersion: v2.5.2

--- a/charts/redpanda-console-oauth2proxy/README.md
+++ b/charts/redpanda-console-oauth2proxy/README.md
@@ -200,13 +200,21 @@ Override the value in `console.config.server.listenPort` if not `nil`
 
 **Default:** `{}`
 
-### [oauth2Proxy.image](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image)
+### [oauth2Proxy.image.registry](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.registry)
 
-**Default:**
+**Default:** `"quay.io/"`
 
-```
-"quay.io/oauth2-proxy/oauth2-proxy:v7.5.1"
-```
+### [oauth2Proxy.image.repository](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.repository)
+
+**Default:** `"oauth2-proxy/oauth2-proxy"`
+
+### [oauth2Proxy.image.pullPolicy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.pullPolicy)
+
+**Default:** `"IfNotPresent"`
+
+### [oauth2Proxy.image.tag](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.tag)
+
+**Default:** `"v7.5.1"`
 
 ### [oauth2Proxy.issuerUrl](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.issuerUrl)
 

--- a/charts/redpanda-console-oauth2proxy/README.md
+++ b/charts/redpanda-console-oauth2proxy/README.md
@@ -6,7 +6,7 @@
 description: Find the default values and descriptions of settings in the Cheetah Redpanda Console Helm chart.
 ---
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.5.2](https://img.shields.io/badge/AppVersion-v2.5.2-informational?style=flat-square)
 
 Disclaimer - This chart is an extension of the official Cheetah Redpanda Console Helm Chart.
 The original source code can be found at https://github.com/redpanda-data/helm-charts/tree/main/charts/console.

--- a/charts/redpanda-console-oauth2proxy/README.md
+++ b/charts/redpanda-console-oauth2proxy/README.md
@@ -202,7 +202,7 @@ Override the value in `console.config.server.listenPort` if not `nil`
 
 ### [oauth2Proxy.image.registry](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.registry)
 
-**Default:** `"quay.io/"`
+**Default:** `"quay.io"`
 
 ### [oauth2Proxy.image.repository](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.repository)
 

--- a/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
+++ b/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
@@ -115,5 +115,5 @@ variable or return the imageRegistry as specified via the values.
 Expand the template to get the complete oauth2proxy image path.
 */}}
 {{- define "oauth2proxy.image" -}}
-{{- printf "%s/%s:%s" .Values.oauth2Proxy.image.registry / .Values.oauth2Proxy.image.repository : .Values.oauth2Proxy.image.tag -}}
+{{- printf "%s/%s:%s" .Values.oauth2Proxy.image.registry .Values.oauth2Proxy.image.repository .Values.oauth2Proxy.image.tag }}
 {{- end -}}

--- a/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
+++ b/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
@@ -109,3 +109,11 @@ variable or return the imageRegistry as specified via the values.
     {{- printf "%s" $registryName -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Expand the template to get the complete oauth2proxy image path.
+*/}}
+{{- define "oauth2proxy.image" -}}
+{{ .Values.oauth2Proxy.image.registry }}{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}
+{{- end -}}

--- a/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
+++ b/charts/redpanda-console-oauth2proxy/templates/_helpers.tpl
@@ -115,5 +115,5 @@ variable or return the imageRegistry as specified via the values.
 Expand the template to get the complete oauth2proxy image path.
 */}}
 {{- define "oauth2proxy.image" -}}
-{{ .Values.oauth2Proxy.image.registry }}{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}
+{{- printf "%s/%s:%s" .Values.oauth2Proxy.image.registry / .Values.oauth2Proxy.image.repository : .Values.oauth2Proxy.image.tag -}}
 {{- end -}}

--- a/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
+++ b/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
@@ -286,8 +286,8 @@ spec:
               {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: oauth2-proxy
-          image: {{.Values.oauth2Proxy.image}}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "oauth2proxy.image" . }}
+          imagePullPolicy: {{.Values.oauth2Proxy.image.pullPolicy}}
           args:
             - --oidc-issuer-url={{.Values.oauth2Proxy.issuerUrl}}
             - --upstream=http://127.0.0.1:8080

--- a/charts/redpanda-console-oauth2proxy/values.yaml
+++ b/charts/redpanda-console-oauth2proxy/values.yaml
@@ -94,7 +94,7 @@ console:
 # Configuration for the oauth2proxy sidecar container.
 oauth2Proxy:
   image:
-    registry: quay.io/
+    registry: quay.io
     repository: oauth2-proxy/oauth2-proxy
     pullPolicy: IfNotPresent
     tag: v7.5.1

--- a/charts/redpanda-console-oauth2proxy/values.yaml
+++ b/charts/redpanda-console-oauth2proxy/values.yaml
@@ -19,6 +19,7 @@
 
 replicaCount: 1
 
+# The image repository and tag for the Cheetah Redpanda Console.
 image:
   registry: docker.redpanda.com
   repository: redpandadata/console
@@ -92,7 +93,11 @@ console:
 
 # Configuration for the oauth2proxy sidecar container.
 oauth2Proxy:
-  image: quay.io/oauth2-proxy/oauth2-proxy:v7.5.1
+  image:
+    registry: quay.io/
+    repository: oauth2-proxy/oauth2-proxy
+    pullPolicy: IfNotPresent
+    tag: v7.5.1
   issuerUrl: ""
   cookieName: __Host-_oauth2Proxy
   emailDomain: "*"


### PR DESCRIPTION
- Added function 'oauth2proxy.image' to generate the complete image path.
- Updated deployment template to use the new helper functions for cleaner and more maintainable configuration.

The change alines with how the redpanda console is configured