### PR TITLE
Set oauth2Proxy.image.pullpolicy = always for bitnami

### DIFF
--- a/charts/redpanda-console-oauth2proxy/README.md
+++ b/charts/redpanda-console-oauth2proxy/README.md
@@ -210,7 +210,7 @@ Override the value in `console.config.server.listenPort` if not `nil`
 
 ### [oauth2Proxy.image.pullPolicy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.pullPolicy)
 
-**Default:** `"IfNotPresent"`
+**Default:** `"Always"`
 
 ### [oauth2Proxy.image.tag](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.tag)
 

--- a/charts/redpanda-console-oauth2proxy/values.yaml
+++ b/charts/redpanda-console-oauth2proxy/values.yaml
@@ -96,7 +96,8 @@ oauth2Proxy:
   image:
     registry: docker.io
     repository: bitnami/oauth2-proxy
-    pullPolicy: IfNotPresent
+    # Bitnami container images are released on a regular basis with the latest distribution packages available
+    pullPolicy: Always
     tag: 7.6.0
   issuerUrl: ""
   cookieName: __Host-_oauth2Proxy


### PR DESCRIPTION
Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.