### PR TITLE
Update OAuth2Proxy with custom auth-logging-format

### DIFF
--- a/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
+++ b/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
@@ -294,6 +294,7 @@ spec:
             - --reverse-proxy=true
             - --email-domain={{.Values.oauth2Proxy.emailDomain}}
             - --cookie-secure=true
+            - --auth-logging-format="{{.Client}} - {{.RequestID}} - [{{.Timestamp}}] [{{.Status}}] {{.Message}}"
             - --cookie-name={{.Values.oauth2Proxy.cookieName}}
             - --provider=oidc
             - --http-address=0.0.0.0:{{.Values.service.port}}

--- a/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
+++ b/charts/redpanda-console-oauth2proxy/templates/deployment.yaml
@@ -294,6 +294,7 @@ spec:
             - --reverse-proxy=true
             - --email-domain={{.Values.oauth2Proxy.emailDomain}}
             - --cookie-secure=true
+            # remove Username from audit log, to prevent PII in logs: https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/#auth-log-format
             - --auth-logging-format="{{.Client}} - {{.RequestID}} - [{{.Timestamp}}] [{{.Status}}] {{.Message}}"
             - --cookie-name={{.Values.oauth2Proxy.cookieName}}
             - --provider=oidc


### PR DESCRIPTION
To ensure no PII audit logging by default. Was originally here:
https://github.com/trifork/cheetah-base/blob/main/redpanda-proxy/redpanda-patch.yaml

but was not carried over to helm chart