### PR TITLE
switch back to quay.io/oauth2-proxy as its more secure after switch t…

### DIFF
--- a/charts/redpanda-console-oauth2proxy/README.md
+++ b/charts/redpanda-console-oauth2proxy/README.md
@@ -202,11 +202,11 @@ Override the value in `console.config.server.listenPort` if not `nil`
 
 ### [oauth2Proxy.image.registry](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.registry)
 
-**Default:** `"docker.io"`
+**Default:** `"quay.io"`
 
 ### [oauth2Proxy.image.repository](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.repository)
 
-**Default:** `"bitnami/oauth2-proxy"`
+**Default:** `"oauth2-proxy/oauth2-proxy"`
 
 ### [oauth2Proxy.image.pullPolicy](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.pullPolicy)
 
@@ -214,7 +214,7 @@ Override the value in `console.config.server.listenPort` if not `nil`
 
 ### [oauth2Proxy.image.tag](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.image.tag)
 
-**Default:** `"7.6.0"`
+**Default:** `"v7.7.0"`
 
 ### [oauth2Proxy.issuerUrl](https://artifacthub.io/packages/helm/redpanda-data/console?modal=values&path=oauth2Proxy.issuerUrl)
 

--- a/charts/redpanda-console-oauth2proxy/values.yaml
+++ b/charts/redpanda-console-oauth2proxy/values.yaml
@@ -94,11 +94,10 @@ console:
 # Configuration for the oauth2proxy sidecar container.
 oauth2Proxy:
   image:
-    registry: docker.io
-    repository: bitnami/oauth2-proxy
-    # Bitnami container images are released on a regular basis with the latest distribution packages available
+    registry: quay.io
+    repository: oauth2-proxy/oauth2-proxy
     pullPolicy: Always
-    tag: 7.6.0
+    tag: v7.7.0
   issuerUrl: ""
   cookieName: __Host-_oauth2Proxy
   emailDomain: "*"


### PR DESCRIPTION
…o distroless/static:nonroot base image

![image](https://github.com/user-attachments/assets/7e797801-4a0c-481c-b059-363100e73f19)
